### PR TITLE
Switch to radial arc projection

### DIFF
--- a/src/algorithm/BaseAlgorithm.cpp
+++ b/src/algorithm/BaseAlgorithm.cpp
@@ -60,7 +60,8 @@ BaseAlgorithm::BaseAlgorithm()
     : m_param_verbose(0),
       m_param_output_type(OutputType::RF_DATA),
       m_param_sound_speed(1540.0f),
-      m_param_noise_amplitude(0.0f)
+      m_param_noise_amplitude(0.0f),
+      m_param_use_arc_projection(true)
 {
 }
 
@@ -87,6 +88,14 @@ void BaseAlgorithm::set_parameter(const std::string& key, const std::string& val
     } else if (key == "noise_amplitude") {
         const auto new_amplitude = std::stof(value);
         m_param_noise_amplitude = new_amplitude;
+    } else if (key == "use_arc_projection") {
+        if (value == "on" || value == "true") {
+            m_param_use_arc_projection = true;
+        } else if (value == "off" || value == "false") {
+            m_param_use_arc_projection = false;
+        } else {
+            throw std::runtime_error("invalid boolean value");
+        }
     } else {
         const auto err_msg = std::string("illegal parameter name: '") + key + std::string("'");
         throw std::runtime_error(err_msg);

--- a/src/algorithm/BaseAlgorithm.hpp
+++ b/src/algorithm/BaseAlgorithm.hpp
@@ -61,6 +61,7 @@ protected:
     int         m_param_verbose;
     OutputType  m_param_output_type;
     float       m_param_noise_amplitude;
+    bool        m_param_use_arc_projection;
 };
 
 }   // end namespace

--- a/src/algorithm/CpuFixedAlgorithm.cpp
+++ b/src/algorithm/CpuFixedAlgorithm.cpp
@@ -67,7 +67,7 @@ void CpuFixedAlgorithm::projection_loop(const Scanline& line, double* time_proj_
         // Use "arc projection" in the radial direction: use length of vector from
         // beam's origin to the scatterer with the same sign as the projection onto
         // the line.
-        if (true) {
+        if (m_param_use_arc_projection) {
 #ifdef __GNUC__
             r = std::copysign(temp.norm(), r);
 #else

--- a/src/algorithm/CpuFixedAlgorithm.cpp
+++ b/src/algorithm/CpuFixedAlgorithm.cpp
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <vector>
 #include <stdexcept>
+#include <cmath>
 #include "bcsim_defines.h"
 #include "CpuFixedAlgorithm.hpp"
 #include "safe_omp.h"
@@ -62,6 +63,17 @@ void CpuFixedAlgorithm::projection_loop(const Scanline& line, double* time_proj_
         bc_float r = temp.dot(line.get_direction());       // radial component
         bc_float l = temp.dot(line.get_lateral_dir());     // lateral component
         bc_float e = temp.dot(line.get_elevational_dir()); // elevational component
+        
+        // Use "arc projection" in the radial direction: use length of vector from
+        // beam's origin to the scatterer with the same sign as the projection onto
+        // the line.
+        if (true) {
+#ifdef __GNUC__
+            r = std::copysign(temp.norm(), r);
+#else
+            r = _copysignf(temp.norm(), r);
+#endif            
+        }
         
         // Add scaled amplitude to closest index
         int closest_index = (int) std::floor(r*2.0*m_excitation.sampling_frequency/(m_param_sound_speed)+0.5f);

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -89,7 +89,7 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, double* time_proj
         // Use "arc projection" in the radial direction: use length of vector from
         // beam's origin to the scatterer with the same sign as the projection onto
         // the line.
-        if (true) {
+        if (m_param_use_arc_projection) {
 #ifdef __GNUC__
             r = std::copysign(temp.norm(), r);
 #else

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <vector>
 #include <stdexcept>
+#include <cmath>
 #include "bcsim_defines.h"
 #include "CpuSplineAlgorithm.hpp"
 #include "bspline.hpp"
@@ -85,6 +86,17 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, double* time_proj
         bc_float l = temp.dot(line.get_lateral_dir());     // lateral component
         bc_float e = temp.dot(line.get_elevational_dir()); // elevational component
         
+        // Use "arc projection" in the radial direction: use length of vector from
+        // beam's origin to the scatterer with the same sign as the projection onto
+        // the line.
+        if (true) {
+#ifdef __GNUC__
+            r = std::copysign(temp.norm(), r);
+#else
+            r = _copysignf(temp.norm(), r);
+#endif            
+        }
+
         // Add scaled amplitude to closest index
         const bc_float sampling_time_step = 1.0/m_excitation.sampling_frequency;
         int closest_index = (int) std::floor(r*2.0/(m_param_sound_speed*sampling_time_step)+0.5f);

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cufft_helpers.h"
 #include "device_launch_parameters.h" // for removing annoying MSVC intellisense error messages
 #include "gpu_alg_common.cuh" // for misc. CUDA kernels
-#include "common_utils.hpp" // for compute_num_rf_samples
+#include <math_functions.h> // for copysignf
 
 namespace bcsim {
 
@@ -58,11 +58,15 @@ __global__ void FixedAlgKernel(float* point_xs,
     float3 point = make_float3(point_xs[global_idx], point_ys[global_idx], point_zs[global_idx]) - origin;
     
     // compute dot products
-    const auto radial_dist  = dot(point, rad_dir);
+    auto radial_dist  = dot(point, rad_dir);
     const auto lateral_dist = dot(point, lat_dir);
     const auto elev_dist    = dot(point, ele_dir);
 
-
+    // Use "arc projection" in the radial direction: use length of vector from
+    // beam's origin to the scatterer with the same sign as the projection onto
+    // the line.
+    radial_dist = copysignf(sqrtf(dot(point,point)), radial_dist);
+    
     const float two_sigma_lateral_squared     = 2.0f*sigma_lateral*sigma_lateral;
     const float two_sigma_elevational_squared = 2.0f*sigma_elevational*sigma_elevational; 
     const float weight = expf(-(lateral_dist*lateral_dist/two_sigma_lateral_squared + elev_dist*elev_dist/two_sigma_elevational_squared));


### PR DESCRIPTION
The projected radial distance used is now computed as the distance from the beam's origin to the scatterer, with the sign from the dot product of this vector and the radial unit direction vector. The dot product is needed to avoid "mirror images". This will be referred to as the "arc projection"

It is possible to disable the arc projection and use the old dot-product projection through set_parameter() using the boolean key "use_arc_projection". It is desirable to be able to use the old dot-product projection since it is slightly faster and the differences are not very large between the methods.
