### PR TITLE
Avoid illegal gridsize x component

### DIFF
--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -113,16 +113,21 @@ void GpuBaseAlgorithm::save_cuda_device_properties() {
     if (m_param_verbose) {
         const auto& p = m_cur_device_prop;
         std::cout << "=== CUDA Device " << m_param_cuda_device_no << ": " << p.name << std::endl;
-        std::cout << "totalGlobMem: "               << p.totalGlobalMem             << std::endl;
-        std::cout << "clockRate: "                  << p.clockRate                  << std::endl;
         std::cout << "Compute capability: "         << p.major << "." << p.minor << std::endl;
+        std::cout << "ECCEnabled: "                 << p.ECCEnabled                 << std::endl;
         std::cout << "asyncEngineCount: "           << p.asyncEngineCount           << std::endl;
-        std::cout << "multiProcessorCount: "        << p.multiProcessorCount        << std::endl;
-        std::cout << "kernelExecTimeoutEnabled: "   << p.kernelExecTimeoutEnabled   << std::endl;
+        std::cout << "canMapHostMemory: "           << p.canMapHostMemory           << std::endl; 
+        std::cout << "clockRate: "                  << p.clockRate                  << std::endl;
         std::cout << "computeMode: "                << p.computeMode                << std::endl;
         std::cout << "concurrentKernels: "          << p.concurrentKernels          << std::endl;
-        std::cout << "ECCEnabled: "                 << p.ECCEnabled                 << std::endl;
+        std::cout << "integrated: "                 << p.integrated                 << std::endl;
+        std::cout << "kernelExecTimeoutEnabled: "   << p.kernelExecTimeoutEnabled   << std::endl;
+        std::cout << "l2CacheSize: "                << p.l2CacheSize                << std::endl;
+        std::cout << "maxGridSize: [" << p.maxGridSize[0] << "," << p.maxGridSize[1] << "," << p.maxGridSize[2] << "]\n";
+        std::cout << "maxThreadsPerBlock: "         << p.maxThreadsPerBlock         << std::endl;
         std::cout << "memoryBusWidth: "             << p.memoryBusWidth             << std::endl;
+        std::cout << "multiProcessorCount: "        << p.multiProcessorCount        << std::endl;
+        std::cout << "totalGlobMem: "               << p.totalGlobalMem             << std::endl;
     }
 }
 

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -45,6 +45,8 @@ GpuBaseAlgorithm::GpuBaseAlgorithm()
       m_param_threads_per_block(128),
       m_store_kernel_details(false)
 {
+    // ensure that CUDA device properties is stored
+    save_cuda_device_properties(m_param_cuda_device_no);
 }
 
 int GpuBaseAlgorithm::get_num_cuda_devices() const {

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -46,7 +46,7 @@ GpuBaseAlgorithm::GpuBaseAlgorithm()
       m_store_kernel_details(false)
 {
     // ensure that CUDA device properties is stored
-    save_cuda_device_properties(m_param_cuda_device_no);
+    save_cuda_device_properties();
 }
 
 int GpuBaseAlgorithm::get_num_cuda_devices() const {
@@ -67,7 +67,7 @@ void GpuBaseAlgorithm::set_parameter(const std::string& key, const std::string& 
         }
         m_param_cuda_device_no = device_no;
         cudaErrorCheck(cudaSetDevice(m_param_cuda_device_no));
-        save_cuda_device_properties(m_param_cuda_device_no);
+        save_cuda_device_properties();
     } else if (key == "cuda_streams") {
         const auto num_streams = std::stoi(value);
         if (num_streams <= 0) {
@@ -103,16 +103,16 @@ void GpuBaseAlgorithm::create_cuda_stream_wrappers(int num_streams) {
     m_can_change_cuda_device = false;
 }
 
-void GpuBaseAlgorithm::save_cuda_device_properties(int device_no) {
+void GpuBaseAlgorithm::save_cuda_device_properties() {
     const auto num_devices = get_num_cuda_devices();
-    if (device_no < 0 || device_no >= num_devices) {
+    if (m_param_cuda_device_no < 0 || m_param_cuda_device_no >= num_devices) {
         throw std::runtime_error("illegal CUDA device number");
     }
-    cudaErrorCheck( cudaGetDeviceProperties(&m_cur_device_prop, device_no) );
+    cudaErrorCheck( cudaGetDeviceProperties(&m_cur_device_prop, m_param_cuda_device_no) );
 
     if (m_param_verbose) {
         const auto& p = m_cur_device_prop;
-        std::cout << "=== CUDA Device " << device_no << ": " << p.name              << std::endl;
+        std::cout << "=== CUDA Device " << m_param_cuda_device_no << ": " << p.name << std::endl;
         std::cout << "totalGlobMem: "               << p.totalGlobalMem             << std::endl;
         std::cout << "clockRate: "                  << p.clockRate                  << std::endl;
         std::cout << "Compute capability: "         << p.major << "." << p.minor << std::endl;

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -163,7 +163,9 @@ void GpuBaseAlgorithm::simulate_lines(std::vector<std::vector<std::complex<bc_fl
     // compute the number of blocks needed to project all scatterers and check that
     // it is not more than what is supported by the device.
     int num_blocks = round_up_div(m_num_scatterers, m_param_threads_per_block);
-    // TODO: check
+    if (num_blocks > m_cur_device_prop.maxGridSize[0]) {
+        throw std::runtime_error("required number of x-blocks is larger than device supports");
+    }
 
     // no delay compenasation is needed when returning the projections only
     size_t delay_compensation_num_samples = static_cast<size_t>(m_excitation.center_index);

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -65,7 +65,7 @@ void GpuBaseAlgorithm::set_parameter(const std::string& key, const std::string& 
         }
         m_param_cuda_device_no = device_no;
         cudaErrorCheck(cudaSetDevice(m_param_cuda_device_no));
-        print_cuda_device_properties(m_param_cuda_device_no);
+        save_cuda_device_properties(m_param_cuda_device_no);
     } else if (key == "cuda_streams") {
         const auto num_streams = std::stoi(value);
         if (num_streams <= 0) {
@@ -101,24 +101,27 @@ void GpuBaseAlgorithm::create_cuda_stream_wrappers(int num_streams) {
     m_can_change_cuda_device = false;
 }
 
-void GpuBaseAlgorithm::print_cuda_device_properties(int device_no) const {
+void GpuBaseAlgorithm::save_cuda_device_properties(int device_no) {
     const auto num_devices = get_num_cuda_devices();
     if (device_no < 0 || device_no >= num_devices) {
         throw std::runtime_error("illegal CUDA device number");
     }
-    cudaDeviceProp prop;
-    cudaErrorCheck( cudaGetDeviceProperties(&prop, device_no) );
-    std::cout << "\n\n=== Device " << device_no << ": " << prop.name               << std::endl;
-    std::cout << "totalGlobMem: "               << prop.totalGlobalMem             << std::endl;
-    std::cout << "clockRate: "                  << prop.clockRate                  << std::endl;
-    std::cout << "Compute capability: "         << prop.major << "." << prop.minor << std::endl;
-    std::cout << "asyncEngineCount: "           << prop.asyncEngineCount           << std::endl;
-    std::cout << "multiProcessorCount: "        << prop.multiProcessorCount        << std::endl;
-    std::cout << "kernelExecTimeoutEnabled: "   << prop.kernelExecTimeoutEnabled   << std::endl;
-    std::cout << "computeMode: "                << prop.computeMode                << std::endl;
-    std::cout << "concurrentKernels: "          << prop.concurrentKernels          << std::endl;
-    std::cout << "ECCEnabled: "                 << prop.ECCEnabled                 << std::endl;
-    std::cout << "memoryBusWidth: "             << prop.memoryBusWidth             << std::endl;
+    cudaErrorCheck( cudaGetDeviceProperties(&m_cur_device_prop, device_no) );
+
+    if (m_param_verbose) {
+        const auto& p = m_cur_device_prop;
+        std::cout << "=== CUDA Device " << device_no << ": " << p.name              << std::endl;
+        std::cout << "totalGlobMem: "               << p.totalGlobalMem             << std::endl;
+        std::cout << "clockRate: "                  << p.clockRate                  << std::endl;
+        std::cout << "Compute capability: "         << p.major << "." << p.minor << std::endl;
+        std::cout << "asyncEngineCount: "           << p.asyncEngineCount           << std::endl;
+        std::cout << "multiProcessorCount: "        << p.multiProcessorCount        << std::endl;
+        std::cout << "kernelExecTimeoutEnabled: "   << p.kernelExecTimeoutEnabled   << std::endl;
+        std::cout << "computeMode: "                << p.computeMode                << std::endl;
+        std::cout << "concurrentKernels: "          << p.concurrentKernels          << std::endl;
+        std::cout << "ECCEnabled: "                 << p.ECCEnabled                 << std::endl;
+        std::cout << "memoryBusWidth: "             << p.memoryBusWidth             << std::endl;
+    }
 }
 
 void GpuBaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -57,7 +57,7 @@ protected:
     
     int get_num_cuda_devices() const;
     
-    void print_cuda_device_properties(int device_no) const;
+    void save_cuda_device_properties(int device_no);
     
     // must be implemented in subclass
     virtual void projection_kernel(int stream_no, const Scanline& scanline, int num_blocks) = 0;
@@ -100,6 +100,9 @@ protected:
     int                                                 m_param_num_cuda_streams;
     int                                                 m_param_threads_per_block;
     bool                                                m_store_kernel_details;
+
+    // Always reflects the current device in use.
+    cudaDeviceProp                                      m_cur_device_prop;
 };
     
 }   // end namespace

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -57,7 +57,7 @@ protected:
     
     int get_num_cuda_devices() const;
     
-    void save_cuda_device_properties(int device_no);
+    void save_cuda_device_properties();
     
     // must be implemented in subclass
     virtual void projection_kernel(int stream_no, const Scanline& scanline, int num_blocks) = 0;

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -60,7 +60,7 @@ protected:
     void print_cuda_device_properties(int device_no) const;
     
     // must be implemented in subclass
-    virtual void projection_kernel(int stream_no, const Scanline& scanline) = 0;
+    virtual void projection_kernel(int stream_no, const Scanline& scanline, int num_blocks) = 0;
     
 protected:
     typedef cufftComplex complex;

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -108,7 +108,7 @@ GpuFixedAlgorithm::GpuFixedAlgorithm()
 {
 }
 
-void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanline) {
+void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanline, int num_blocks) {
     auto cur_stream = m_stream_wrappers[stream_no]->get();
 
     // TODO: Move out conversion code            
@@ -121,7 +121,6 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
     auto ele_dir      = make_float3(temp_ele_dir.x, temp_ele_dir.y, temp_ele_dir.z);
     auto origin       = make_float3(temp_origin.x, temp_origin.y, temp_origin.z);
 
-    int num_blocks = round_up_div(m_num_scatterers, m_param_threads_per_block);
     dim3 grid_size(num_blocks, 1, 1);
     dim3 block_size(m_param_threads_per_block, 1, 1);
     

--- a/src/algorithm/GpuFixedAlgorithm.cuh
+++ b/src/algorithm/GpuFixedAlgorithm.cuh
@@ -52,7 +52,7 @@ public:
 protected:
     void copy_scatterers_to_device(FixedScatterers::s_ptr scatterers);
 
-    virtual void projection_kernel(int stream_no, const Scanline& scanline) override;
+    virtual void projection_kernel(int stream_no, const Scanline& scanline, int num_blocks) override;
     
 protected:
     // device memory for fixed scatterers

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -148,7 +148,7 @@ void GpuSplineAlgorithm2::set_parameter(const std::string& key, const std::strin
     }
 }
 
-void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanline) {
+void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanline, int num_blocks) {
     auto cur_stream = m_stream_wrappers[stream_no]->get();
     
     // TODO: Move out conversion code            
@@ -174,7 +174,6 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
                                             cudaMemcpyHostToDevice,
                                             cur_stream));
 
-    int num_blocks = round_up_div(m_num_scatterers, m_param_threads_per_block);
     dim3 grid_size(num_blocks, 1, 1);
     dim3 block_size(m_param_threads_per_block, 1, 1);
 

--- a/src/algorithm/GpuSplineAlgorithm2.cuh
+++ b/src/algorithm/GpuSplineAlgorithm2.cuh
@@ -53,7 +53,7 @@ public:
 protected:
     void copy_scatterers_to_device(SplineScatterers::s_ptr scatterers);
 
-    virtual void projection_kernel(int stream_no, const Scanline& scanline) override;
+    virtual void projection_kernel(int stream_no, const Scanline& scanline, int num_blocks) override;
     
 protected:
     


### PR DESCRIPTION
Checking that the device actually supports the number of blocks required when projecting the scatterers. Older devices are limited at 65535, which can become a problem for large number of scatterers.
