### PR TITLE
Improved lut beamprofile support

### DIFF
--- a/create_all_phantoms.py
+++ b/create_all_phantoms.py
@@ -223,6 +223,18 @@ def create_2d_cyst_phantom():
     args.density = 500.0
     args.cyst_scale = 0.3
     create_phantom(args)
+
+def create_simple_phantom():
+    """
+    A few scatterers along the positive z-axis.
+    """
+    from simple import create_phantom
+    args = Args()
+    args.h5_file = os.path.join(out_dir, "simple.h5")
+    args.num_scatterers=12
+    args.z0 = 0.005
+    args.z1 = 0.12
+    create_phantom(args)
     
 if __name__ == '__main__':
     verify_correct_path()
@@ -235,6 +247,7 @@ if __name__ == '__main__':
     create_random_spline_noise_phantom()
     create_harmonic_box_phantom()
     create_2d_cyst_phantom()
+    create_simple_phantom()
     print 'NOTE: This is the last script and may take a while to finish...'
-    create_artery_phantom()
+    #create_artery_phantom()
     

--- a/phantom_scripts/simple.py
+++ b/phantom_scripts/simple.py
@@ -1,0 +1,30 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import h5py
+import argparse
+
+description="""
+    Create a few point scatterers along the positive z-axis.
+    This is useful to test lookup-table beam profiles.
+"""
+
+def create_phantom(args):
+    data = np.ones((args.num_scatterers,4), dtype="float32")
+    data[:,0] = np.zeros((args.num_scatterers,))
+    data[:,1] = np.zeros((args.num_scatterers,))
+    data[:,2] = np.linspace(args.z0, args.z1, args.num_scatterers)
+    
+    with h5py.File(args.h5_file, "w") as f:
+        f["data"] = data
+    print "Dataset written to %s" % args.h5_file
+        
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("h5_file", help="Name of scatterer hdf5 file")
+    parser.add_argument("--num_scatterers", type=int, default=12)
+    parser.add_argument("--z0", type=float, default=0.0)
+    parser.add_argument("--z1", type=float, default=0.12)
+    args = parser.parse_args()
+    
+    create_phantom(args)
+    

--- a/src/BeamProfile.cpp
+++ b/src/BeamProfile.cpp
@@ -90,9 +90,9 @@ bc_float LUTBeamProfile::sampleProfile(bc_float r, bc_float l, bc_float e) {
     const auto e0 = static_cast<int>(temp_e); const auto e1 = static_cast<int>(temp_e+1);
     
     // fractional parts
-    const auto dr = static_cast<bc_float>(temp_r - r0);
-    const auto dl = static_cast<bc_float>(temp_l - l0);
-    const auto de = static_cast<bc_float>(temp_e - e0);
+    const auto fractional_r = static_cast<bc_float>(temp_r - r0);
+    const auto fractional_l = static_cast<bc_float>(temp_l - l0);
+    const auto fractional_e = static_cast<bc_float>(temp_e - e0);
 
     // return zeros outside
     if ((r0 < 0) || (r0 >= m_num_samples_rad) || (r1 < 0) || (r1 >= m_num_samples_rad)) {
@@ -117,17 +117,17 @@ bc_float LUTBeamProfile::sampleProfile(bc_float r, bc_float l, bc_float e) {
     c111 = m_samples[getIndex(r1, l1, e1)];
 
     // radial interpolation
-    const auto c00 = (1.0f-dr)*c000 + dr*c100;
-    const auto c10 = (1.0f-dr)*c010 + dr*c110;
-    const auto c01 = (1.0f-dr)*c001 + dr*c101;
-    const auto c11 = (1.0f-dr)*c011 + dr*c111;
+    const auto c00 = (1.0f-fractional_r)*c000 + fractional_r*c100;
+    const auto c10 = (1.0f-fractional_r)*c010 + fractional_r*c110;
+    const auto c01 = (1.0f-fractional_r)*c001 + fractional_r*c101;
+    const auto c11 = (1.0f-fractional_r)*c011 + fractional_r*c111;
 
     // lateral interpolation
-    const auto c0 = (1.0f-dl)*c00 + dl*c10;
-    const auto c1 = (1.0f-dl)*c01 + dl*c11;
+    const auto c0 = (1.0f-fractional_l)*c00 + fractional_l*c10;
+    const auto c1 = (1.0f-fractional_l)*c01 + fractional_l*c11;
 
     // finally, elevational interpolation
-    return (1.0f-de)*c0 + de*c1;
+    return (1.0f-fractional_e)*c0 + fractional_e*c1;
 }
 
 void LUTBeamProfile::setDiscreteSample(int ir, int il, int ie, bc_float new_sample) {

--- a/src/BeamProfile.hpp
+++ b/src/BeamProfile.hpp
@@ -98,6 +98,30 @@ public:
     // Set sample based on discrete indices.
     void setDiscreteSample(int ir, int il, int ie, bc_float new_sample);
 
+    Interval getRangeRange() const {
+        return m_range_range;
+    }
+
+    Interval getLateralRange() const {
+        return m_lateral_range;
+    }
+
+    Interval getElevationalRange() const {
+        return m_elevational_range;
+    }
+
+    int getNumSamplesRadial() const {
+        return m_num_samples_rad;
+    }
+
+    int getNumSamplesLateral() const {
+        return m_num_samples_lat;
+    }
+
+    int getNumSamplesElevational() const {
+        return m_num_samples_ele;
+    }
+
 protected:
     // row-major indexing
     // dim0: radial, dim1: lateral, dim2: elevational

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,6 +160,7 @@ if (BCSIM_ENABLE_CUDA)
                      algorithm/GpuSplineAlgorithm2.cuh
                      algorithm/cuda_helpers.h
                      algorithm/cufft_helpers.h
+                     algorithm/cuda_debug_utils.h
                      )
     target_link_libraries(BCSimCUDA
                           ${CUDA_LIBRARIES}

--- a/src/HDFConvenience.cpp
+++ b/src/HDFConvenience.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <stdexcept>
 #include <boost/multi_array.hpp>
+#include <algorithm>
 #include "bcsim_defines.h"
 #include "HDFConvenience.hpp"
 #include "ScanSequence.hpp"
@@ -255,7 +256,11 @@ IBeamProfile::s_ptr loadBeamProfileFromHdf(const std::string& h5_file) {
     
     auto lut_profile = new LUTBeamProfile(num_rad_samples, num_lat_samples, num_ele_samples,
                                           Interval(r_min, r_max), Interval(l_min, l_max), Interval(e_min, e_max));
-			
+
+
+    // Normalize so that maximum is one
+    const auto max_val = *std::max_element(lut_samples.origin(), lut_samples.origin()+lut_samples.num_elements());
+
     // Copy data. TODO: require matching hdf5 layout so that copying can be eliminated
     // dim0: radial index
     // dim1: lateral index
@@ -263,7 +268,7 @@ IBeamProfile::s_ptr loadBeamProfileFromHdf(const std::string& h5_file) {
     for (size_t rad_idx = 0; rad_idx < num_rad_samples; rad_idx++) {
         for (size_t lat_idx = 0; lat_idx < num_lat_samples; lat_idx++) {
             for (int ele_idx = 0; ele_idx < num_ele_samples; ele_idx++) {
-                lut_profile->setDiscreteSample(rad_idx, lat_idx, ele_idx, lut_samples[rad_idx][lat_idx][ele_idx]);       
+                lut_profile->setDiscreteSample(rad_idx, lat_idx, ele_idx, lut_samples[rad_idx][lat_idx][ele_idx]/max_val);       
             }
         }
     }

--- a/src/HDFConvenience.cpp
+++ b/src/HDFConvenience.cpp
@@ -122,7 +122,7 @@ void setExcitationFromHdf(IAlgorithm::s_ptr sim, const std::string& h5_file) {
 
 void setBeamProfileFromHdf(IAlgorithm::s_ptr sim, const std::string& h5_file) {
     auto lut_beamprofile = loadBeamProfileFromHdf(h5_file);
-    sim->set_beam_profile(lut_beamprofile);
+    sim->set_lookup_profile(lut_beamprofile);
 }
 
 Scatterers::s_ptr loadFixedScatterersFromHdf(const std::string& h5_file) {

--- a/src/LibBCSim.hpp
+++ b/src/LibBCSim.hpp
@@ -60,7 +60,13 @@ public:
     virtual void set_excitation(const ExcitationSignal& new_excitation)                 = 0;
 
     // Set the beam profile object to use when simulating.
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     = 0;
+    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     = 0; // TODO: remove
+
+    // Configure an analytical Gaussian beam profile.
+    virtual void set_analytical_profile(float sigma_lateral, float sigma_elevational)   = 0;
+
+    // Configure a lookup table based beam profile.
+    virtual void set_lookup_profile()                                                   = 0; // TODO: final interface
 
     // Simulate all RF lines. Returns vector of IQ samples.
     // Requires that everything is properly configured.

--- a/src/LibBCSim.hpp
+++ b/src/LibBCSim.hpp
@@ -63,10 +63,10 @@ public:
     virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     = 0; // TODO: remove
 
     // Configure an analytical Gaussian beam profile.
-    virtual void set_analytical_profile(float sigma_lateral, float sigma_elevational)   = 0;
+    virtual void set_analytical_profile(IBeamProfile::s_ptr beam_profile)               = 0; // TODO: final arguments: float sigma_lateral, float sigma_elevational
 
     // Configure a lookup table based beam profile.
-    virtual void set_lookup_profile()                                                   = 0; // TODO: final interface
+    virtual void set_lookup_profile(IBeamProfile::s_ptr beam_profile)                   = 0; // TODO: final arguements: ?
 
     // Simulate all RF lines. Returns vector of IQ samples.
     // Requires that everything is properly configured.

--- a/src/LibBCSim.hpp
+++ b/src/LibBCSim.hpp
@@ -59,9 +59,6 @@ public:
     // Set the excitation signal to use when convolving.
     virtual void set_excitation(const ExcitationSignal& new_excitation)                 = 0;
 
-    // Set the beam profile object to use when simulating.
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     = 0; // TODO: remove
-
     // Configure an analytical Gaussian beam profile.
     virtual void set_analytical_profile(IBeamProfile::s_ptr beam_profile)               = 0; // TODO: final arguments: float sigma_lateral, float sigma_elevational
 

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -207,7 +207,7 @@ public:
     void set_analytical_beam_profile(float sigmaLateral, float sigmaElevational) {
         // TODO: Plug memleak
         auto beam_profile = IBeamProfile::s_ptr(new GaussianBeamProfile(sigmaLateral, sigmaElevational));
-        m_rf_simulator->set_beam_profile(beam_profile);
+        m_rf_simulator->set_analytical_profile(beam_profile);
         if (m_print_debug) {
             std::cout << "Lateral sigma is now " << sigmaLateral << " [m]" << std::endl;
             std::cout << "Elevational sigma is now " << sigmaElevational << " [m]" << std::endl;
@@ -258,7 +258,7 @@ public:
                 }
             }
         }
-        m_rf_simulator->set_beam_profile(IBeamProfile::s_ptr(lut));
+        m_rf_simulator->set_lookup_profile(IBeamProfile::s_ptr(lut));
     }
 
     PyObject* simulate_lines() {

--- a/src/algorithm/BaseAlgorithm.cpp
+++ b/src/algorithm/BaseAlgorithm.cpp
@@ -40,7 +40,6 @@ BaseAlgorithm::BaseAlgorithm()
       m_param_use_arc_projection(true),
       m_radial_decimation(1),
       m_enable_phase_delay(false),
-      m_beam_profile(nullptr),
       m_beam_profile_configured(false)
 {
 }
@@ -94,7 +93,14 @@ std::vector<double> BaseAlgorithm::get_debug_data(const std::string& identifier)
 }
 
 void BaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {
-    m_beam_profile = beam_profile;
+    // TEMPORARY: redirect
+    if (std::dynamic_pointer_cast<GaussianBeamProfile>(beam_profile)) {
+        set_analytical_profile(beam_profile);
+    } else if (std::dynamic_pointer_cast<LUTBeamProfile>(beam_profile)) {
+        set_lookup_profile(beam_profile);
+    } else {
+        throw std::runtime_error("BaseAlgorithm::set_beam_profile(): All casts failed");
+    }
     m_beam_profile_configured = true;
 }
 

--- a/src/algorithm/BaseAlgorithm.cpp
+++ b/src/algorithm/BaseAlgorithm.cpp
@@ -92,17 +92,5 @@ std::vector<double> BaseAlgorithm::get_debug_data(const std::string& identifier)
     return m_debug_data.at(identifier);
 }
 
-void BaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {
-    // TEMPORARY: redirect
-    if (std::dynamic_pointer_cast<GaussianBeamProfile>(beam_profile)) {
-        set_analytical_profile(beam_profile);
-    } else if (std::dynamic_pointer_cast<LUTBeamProfile>(beam_profile)) {
-        set_lookup_profile(beam_profile);
-    } else {
-        throw std::runtime_error("BaseAlgorithm::set_beam_profile(): All casts failed");
-    }
-}
-
-
 }   // end namespace
 

--- a/src/algorithm/BaseAlgorithm.cpp
+++ b/src/algorithm/BaseAlgorithm.cpp
@@ -39,7 +39,9 @@ BaseAlgorithm::BaseAlgorithm()
       m_param_noise_amplitude(0.0f),
       m_param_use_arc_projection(true),
       m_radial_decimation(1),
-      m_enable_phase_delay(false)
+      m_enable_phase_delay(false),
+      m_beam_profile(nullptr),
+      m_beam_profile_configured(false)
 {
 }
 
@@ -89,6 +91,11 @@ std::vector<double> BaseAlgorithm::get_debug_data(const std::string& identifier)
         throw std::runtime_error("invalid debug data key: " + identifier);
     }
     return m_debug_data.at(identifier);
+}
+
+void BaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {
+    m_beam_profile = beam_profile;
+    m_beam_profile_configured = true;
 }
 
 

--- a/src/algorithm/BaseAlgorithm.cpp
+++ b/src/algorithm/BaseAlgorithm.cpp
@@ -40,7 +40,8 @@ BaseAlgorithm::BaseAlgorithm()
       m_param_use_arc_projection(true),
       m_radial_decimation(1),
       m_enable_phase_delay(false),
-      m_beam_profile_configured(false)
+      m_beam_profile_configured(false),
+      m_cur_beam_profile_type(BeamProfileType::NOT_CONFIGURED)
 {
 }
 

--- a/src/algorithm/BaseAlgorithm.cpp
+++ b/src/algorithm/BaseAlgorithm.cpp
@@ -40,7 +40,6 @@ BaseAlgorithm::BaseAlgorithm()
       m_param_use_arc_projection(true),
       m_radial_decimation(1),
       m_enable_phase_delay(false),
-      m_beam_profile_configured(false),
       m_cur_beam_profile_type(BeamProfileType::NOT_CONFIGURED)
 {
 }
@@ -102,7 +101,6 @@ void BaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {
     } else {
         throw std::runtime_error("BaseAlgorithm::set_beam_profile(): All casts failed");
     }
-    m_beam_profile_configured = true;
 }
 
 

--- a/src/algorithm/BaseAlgorithm.hpp
+++ b/src/algorithm/BaseAlgorithm.hpp
@@ -63,7 +63,6 @@ protected:
 
     // The beam profile (analytical expression or LUT)
     BeamProfileType m_cur_beam_profile_type; 
-    bool        m_beam_profile_configured;
 
     // storage of debug data
     std::map<std::string, std::vector<double>>  m_debug_data;

--- a/src/algorithm/BaseAlgorithm.hpp
+++ b/src/algorithm/BaseAlgorithm.hpp
@@ -45,6 +45,8 @@ public:
     virtual void set_parameter(const std::string& key, const std::string& value) override;
 
     virtual std::vector<double> get_debug_data(const std::string& identifier) const override;
+
+    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override;
     
 protected:
     float       m_param_sound_speed;
@@ -53,6 +55,10 @@ protected:
     bool        m_param_use_arc_projection;
     int         m_radial_decimation;
     bool        m_enable_phase_delay;
+
+    // The beam profile (analytical expression or LUT)
+    IBeamProfile::s_ptr                         m_beam_profile;
+    bool                                        m_beam_profile_configured; 
 
     // storage of debug data
     std::map<std::string, std::vector<double>>  m_debug_data;

--- a/src/algorithm/BaseAlgorithm.hpp
+++ b/src/algorithm/BaseAlgorithm.hpp
@@ -50,7 +50,7 @@ public:
 
     virtual std::vector<double> get_debug_data(const std::string& identifier) const override;
 
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override;
+    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override; // TODO: remove
 
 protected:
     float       m_param_sound_speed;
@@ -61,9 +61,8 @@ protected:
     bool        m_enable_phase_delay;
 
     // The beam profile (analytical expression or LUT)
-    IBeamProfile::s_ptr                         m_beam_profile;             // TODO: rmeove
-    bool                                        m_beam_profile_configured;  // TODO: remove
     BeamProfile m_cur_beam_profile_type; 
+    bool        m_beam_profile_configured;
 
     // storage of debug data
     std::map<std::string, std::vector<double>>  m_debug_data;

--- a/src/algorithm/BaseAlgorithm.hpp
+++ b/src/algorithm/BaseAlgorithm.hpp
@@ -35,7 +35,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace bcsim {
 
-enum class BeamProfile {
+enum class BeamProfileType {
+    NOT_CONFIGURED = 0,
     ANALYTICAL,     // Analytical Gaussian beam profile
     LOOKUP          // Lookup-table based beam profile
 };
@@ -61,7 +62,7 @@ protected:
     bool        m_enable_phase_delay;
 
     // The beam profile (analytical expression or LUT)
-    BeamProfile m_cur_beam_profile_type; 
+    BeamProfileType m_cur_beam_profile_type; 
     bool        m_beam_profile_configured;
 
     // storage of debug data

--- a/src/algorithm/BaseAlgorithm.hpp
+++ b/src/algorithm/BaseAlgorithm.hpp
@@ -51,8 +51,6 @@ public:
 
     virtual std::vector<double> get_debug_data(const std::string& identifier) const override;
 
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override; // TODO: remove
-
 protected:
     float       m_param_sound_speed;
     int         m_param_verbose;

--- a/src/algorithm/BaseAlgorithm.hpp
+++ b/src/algorithm/BaseAlgorithm.hpp
@@ -35,6 +35,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace bcsim {
 
+enum class BeamProfile {
+    ANALYTICAL,     // Analytical Gaussian beam profile
+    LOOKUP          // Lookup-table based beam profile
+};
     
 // Common functionality for CPU- and GPU-algorithms.
 class BaseAlgorithm : public IAlgorithm {
@@ -47,7 +51,7 @@ public:
     virtual std::vector<double> get_debug_data(const std::string& identifier) const override;
 
     virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override;
-    
+
 protected:
     float       m_param_sound_speed;
     int         m_param_verbose;
@@ -57,8 +61,9 @@ protected:
     bool        m_enable_phase_delay;
 
     // The beam profile (analytical expression or LUT)
-    IBeamProfile::s_ptr                         m_beam_profile;
-    bool                                        m_beam_profile_configured; 
+    IBeamProfile::s_ptr                         m_beam_profile;             // TODO: rmeove
+    bool                                        m_beam_profile_configured;  // TODO: remove
+    BeamProfile m_cur_beam_profile_type; 
 
     // storage of debug data
     std::map<std::string, std::vector<double>>  m_debug_data;

--- a/src/algorithm/CpuBaseAlgorithm.cpp
+++ b/src/algorithm/CpuBaseAlgorithm.cpp
@@ -210,10 +210,18 @@ void CpuBaseAlgorithm::configure_convolvers_if_possible() {
 }
 
 void CpuBaseAlgorithm::throw_if_not_configured() {
-    if (!m_scan_sequence_configured)    throw std::runtime_error("Scan sequence not configured.");
-    if (!m_excitation_configured)       throw std::runtime_error("Excitation not configured.");
-    if (!m_beam_profile_configured)     throw std::runtime_error("Beam profile not configured.");
-    if (!m_scatterers_configured)       throw std::runtime_error("Scatterers not configured.");
+    if (!m_scan_sequence_configured) {
+        throw std::runtime_error("Scan sequence not configured.");
+    }
+    if (!m_excitation_configured) {
+        throw std::runtime_error("Excitation not configured.");
+    }
+    if (m_cur_beam_profile_type == BeamProfileType::NOT_CONFIGURED){
+        throw std::runtime_error("Beam profile not configured.");
+    }
+    if (!m_scatterers_configured) {
+        throw std::runtime_error("Scatterers not configured.");
+    }
 }
 
 void CpuBaseAlgorithm::set_analytical_profile(IBeamProfile::s_ptr beam_profile) {

--- a/src/algorithm/CpuBaseAlgorithm.cpp
+++ b/src/algorithm/CpuBaseAlgorithm.cpp
@@ -216,5 +216,13 @@ void CpuBaseAlgorithm::throw_if_not_configured() {
     if (!m_scatterers_configured)       throw std::runtime_error("Scatterers not configured.");
 }
 
+void CpuBaseAlgorithm::set_analytical_profile(float lateral_sigma, float elevational_sigma) {
+    // TODO
+}
+
+void CpuBaseAlgorithm::set_lookup_profile() {
+    // TODO
+}
+
 }   // namespace
 

--- a/src/algorithm/CpuBaseAlgorithm.cpp
+++ b/src/algorithm/CpuBaseAlgorithm.cpp
@@ -218,14 +218,22 @@ void CpuBaseAlgorithm::throw_if_not_configured() {
 
 void CpuBaseAlgorithm::set_analytical_profile(IBeamProfile::s_ptr beam_profile) {
     std::cout << "Setting analytical beam profile for CPU algorithm" << std::endl;
+
+    const auto temp = std::dynamic_pointer_cast<GaussianBeamProfile>(beam_profile);
+    if (!temp) throw std::runtime_error("CpuBaseAlgorithm: failed to cast beam profile");
     m_cur_beam_profile_type = BeamProfile::ANALYTICAL;
-    // TODO
+
+    m_beam_profile = beam_profile;
 }
 
 void CpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
     std::cout << "Setting LUT beam profile for CPU algorithm" << std::endl;
+
+    const auto temp = std::dynamic_pointer_cast<LUTBeamProfile>(beam_profile);
+    if (!temp) throw std::runtime_error("CpuBaseAlgorithm: failed to cast beam profile");
     m_cur_beam_profile_type = BeamProfile::LOOKUP;
-    // TODO
+
+    m_beam_profile = beam_profile;
 }
 
 }   // namespace

--- a/src/algorithm/CpuBaseAlgorithm.cpp
+++ b/src/algorithm/CpuBaseAlgorithm.cpp
@@ -216,11 +216,15 @@ void CpuBaseAlgorithm::throw_if_not_configured() {
     if (!m_scatterers_configured)       throw std::runtime_error("Scatterers not configured.");
 }
 
-void CpuBaseAlgorithm::set_analytical_profile(float lateral_sigma, float elevational_sigma) {
+void CpuBaseAlgorithm::set_analytical_profile(IBeamProfile::s_ptr beam_profile) {
+    std::cout << "Setting analytical beam profile for CPU algorithm" << std::endl;
+    m_cur_beam_profile_type = BeamProfile::ANALYTICAL;
     // TODO
 }
 
-void CpuBaseAlgorithm::set_lookup_profile() {
+void CpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
+    std::cout << "Setting LUT beam profile for CPU algorithm" << std::endl;
+    m_cur_beam_profile_type = BeamProfile::LOOKUP;
     // TODO
 }
 

--- a/src/algorithm/CpuBaseAlgorithm.cpp
+++ b/src/algorithm/CpuBaseAlgorithm.cpp
@@ -221,7 +221,7 @@ void CpuBaseAlgorithm::set_analytical_profile(IBeamProfile::s_ptr beam_profile) 
 
     const auto temp = std::dynamic_pointer_cast<GaussianBeamProfile>(beam_profile);
     if (!temp) throw std::runtime_error("CpuBaseAlgorithm: failed to cast beam profile");
-    m_cur_beam_profile_type = BeamProfile::ANALYTICAL;
+    m_cur_beam_profile_type = BeamProfileType::ANALYTICAL;
 
     m_beam_profile = beam_profile;
 }
@@ -231,7 +231,7 @@ void CpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
 
     const auto temp = std::dynamic_pointer_cast<LUTBeamProfile>(beam_profile);
     if (!temp) throw std::runtime_error("CpuBaseAlgorithm: failed to cast beam profile");
-    m_cur_beam_profile_type = BeamProfile::LOOKUP;
+    m_cur_beam_profile_type = BeamProfileType::LOOKUP;
 
     m_beam_profile = beam_profile;
 }

--- a/src/algorithm/CpuBaseAlgorithm.cpp
+++ b/src/algorithm/CpuBaseAlgorithm.cpp
@@ -50,7 +50,6 @@ namespace bcsim {
 CpuBaseAlgorithm::CpuBaseAlgorithm()
         : m_scan_sequence_configured(false),
           m_excitation_configured(false),
-          m_beam_profile_configured(false),
           m_scatterers_configured(false),
           m_omp_num_threads(1) {
     
@@ -123,11 +122,6 @@ void CpuBaseAlgorithm::set_excitation(const ExcitationSignal& new_excitation) {
     m_excitation_configured = true;
     configure_convolvers_if_possible();
 }   
-
-void CpuBaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {
-    m_beamProfile = beam_profile;
-    m_beam_profile_configured = true;
-}
 
 void CpuBaseAlgorithm::simulate_lines(std::vector<std::vector<std::complex<bc_float>> > & rfLines) {
     throw_if_not_configured();

--- a/src/algorithm/CpuBaseAlgorithm.hpp
+++ b/src/algorithm/CpuBaseAlgorithm.hpp
@@ -104,6 +104,9 @@ protected:
     // signal prior to convolution.
     std::default_random_engine      m_random_engine;
     std::normal_distribution<float> m_normal_dist;
+
+    // Current active beam profile.
+    IBeamProfile::s_ptr             m_beam_profile;         // TEMPORARY
 };
 
 }   // end namespace

--- a/src/algorithm/CpuBaseAlgorithm.hpp
+++ b/src/algorithm/CpuBaseAlgorithm.hpp
@@ -51,7 +51,11 @@ public:
     virtual void set_excitation(const ExcitationSignal& new_excitation)                 override;
 
     virtual void simulate_lines(std::vector<std::vector<std::complex<bc_float>> >&  /*out*/ rf_lines) override;
-    
+
+    virtual void set_analytical_profile(float lateral_sigma, float elevational_sigma) override;
+
+    virtual void set_lookup_profile() override;
+
 protected:
     // Use as many cores as possible for simulation.
     void set_use_all_available_cores();

--- a/src/algorithm/CpuBaseAlgorithm.hpp
+++ b/src/algorithm/CpuBaseAlgorithm.hpp
@@ -50,8 +50,6 @@ public:
 
     virtual void set_excitation(const ExcitationSignal& new_excitation)                 override;
 
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     override;
-
     virtual void simulate_lines(std::vector<std::vector<std::complex<bc_float>> >&  /*out*/ rf_lines) override;
     
 protected:
@@ -85,8 +83,6 @@ protected:
     ExcitationSignal                         m_excitation;
     // Pointer to one FFT-convolver for each thread.
     std::vector<IBeamConvolver::ptr>         convolvers;
-    // The beam profile (analytical expression or LUT)
-    IBeamProfile::s_ptr                      m_beamProfile;
     
     // The number of time samples in each RF line in the scan sequence.
     size_t                                  m_rf_line_num_samples;
@@ -95,7 +91,6 @@ protected:
     // before doing the simulations.
     bool m_scan_sequence_configured;
     bool m_excitation_configured;
-    bool m_beam_profile_configured; 
     bool m_scatterers_configured;   
     
     // Number of threads to use for simulation.

--- a/src/algorithm/CpuBaseAlgorithm.hpp
+++ b/src/algorithm/CpuBaseAlgorithm.hpp
@@ -52,9 +52,9 @@ public:
 
     virtual void simulate_lines(std::vector<std::vector<std::complex<bc_float>> >&  /*out*/ rf_lines) override;
 
-    virtual void set_analytical_profile(float lateral_sigma, float elevational_sigma) override;
+    virtual void set_analytical_profile(IBeamProfile::s_ptr beam_profile) override;
 
-    virtual void set_lookup_profile() override;
+    virtual void set_lookup_profile(IBeamProfile::s_ptr beam_profile) override;
 
 protected:
     // Use as many cores as possible for simulation.

--- a/src/algorithm/CpuFixedAlgorithm.cpp
+++ b/src/algorithm/CpuFixedAlgorithm.cpp
@@ -78,7 +78,7 @@ void CpuFixedAlgorithm::projection_loop(const Scanline& line, std::complex<float
         // Add scaled amplitude to closest index
         int closest_index = (int) std::floor(r*2.0*m_excitation.sampling_frequency/(m_param_sound_speed)+0.5f);
 
-        bc_float scaled_ampl = m_beamProfile->sampleProfile(r,l,e)*scatterer.amplitude;
+        bc_float scaled_ampl = m_beam_profile->sampleProfile(r,l,e)*scatterer.amplitude;
         
         // Avoid out of bound seg.fault
         if (closest_index < 0 || closest_index >= num_time_samples) {

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -101,7 +101,7 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
         const bc_float sampling_time_step = 1.0/m_excitation.sampling_frequency;
         int closest_index = (int) std::floor(r*2.0/(m_param_sound_speed*sampling_time_step)+0.5f);
         
-        bc_float scaled_ampl = m_beamProfile->sampleProfile(r,l,e)*scatterer.amplitude;
+        bc_float scaled_ampl = m_beam_profile->sampleProfile(r,l,e)*scatterer.amplitude;
         
         // Avoid out of bound seg.fault
         if (closest_index < 0 || closest_index >= num_time_samples) {

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -359,7 +359,7 @@ void GpuBaseAlgorithm::set_analytical_profile(IBeamProfile::s_ptr beam_profile) 
     std::cout << "Setting analytical beam profile for GPU algorithm" << std::endl;
     const auto analytical_profile = std::dynamic_pointer_cast<GaussianBeamProfile>(beam_profile);
     if (!analytical_profile) throw std::runtime_error("GpuBaseAlgorithm: failed to cast beam profile");
-    m_cur_beam_profile_type = BeamProfile::ANALYTICAL;
+    m_cur_beam_profile_type = BeamProfileType::ANALYTICAL;
 
     m_analytical_sigma_lat = analytical_profile->getSigmaLateral();
     m_analytical_sigma_ele = analytical_profile->getSigmaElevational();
@@ -369,7 +369,7 @@ void GpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
     std::cout << "Setting LUT profile for GPU algorithm" << std::endl;
     const auto lut_beam_profile = std::dynamic_pointer_cast<LUTBeamProfile>(beam_profile);
     if (!lut_beam_profile) throw std::runtime_error("GpuBaseAlgorithm: failed to cast beam profile");
-    m_cur_beam_profile_type = BeamProfile::LOOKUP;
+    m_cur_beam_profile_type = BeamProfileType::LOOKUP;
 
     int num_samples_rad = lut_beam_profile->getNumSamplesRadial();
     int num_samples_lat = lut_beam_profile->getNumSamplesLateral();

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -430,5 +430,13 @@ void GpuBaseAlgorithm::set_scan_sequence(ScanSequence::s_ptr new_scan_sequence) 
     m_num_beams_allocated = static_cast<int>(num_beams);
 }
 
+void GpuBaseAlgorithm::set_analytical_profile(float lateral_sigma, float elevational_sigma) {
+    // TODO: Implement
+}
+
+void GpuBaseAlgorithm::set_lookup_profile() {
+    // TODO: Implement
+}
+
 }   // end namespace
 

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -374,7 +374,7 @@ void GpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
     int num_samples_rad = lut_beam_profile->getNumSamplesRadial();
     int num_samples_lat = lut_beam_profile->getNumSamplesLateral();
     int num_samples_ele = lut_beam_profile->getNumSamplesElevational();
-    std::cout << "=== set_beam_profile() ===" << std::endl;
+    std::cout << "=== set_lookup_profile() ===" << std::endl;
     std::cout << "num_samples_rad: " << num_samples_rad << std::endl;
     std::cout << "num_samples_lat: " << num_samples_lat << std::endl;
     std::cout << "num_samples_ele: " << num_samples_ele << std::endl;

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -132,6 +132,13 @@ void GpuBaseAlgorithm::save_cuda_device_properties() {
 
 void GpuBaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {
     m_beam_profile = beam_profile;
+
+    // If lookup-table: cache a CUDA version of it
+    const auto lut_beam_profile = std::dynamic_pointer_cast<bcsim::LUTBeamProfile>(beam_profile);
+    if (lut_beam_profile) {
+        std::cout << "Creating CUDA lookup-table\n";
+        throw std::runtime_error("TODO: copy data");
+    }
 }
 
 

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -410,7 +410,7 @@ void GpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
     std::cout << "Created a new DeviceBeamProfileRAII.\n";
     
     const std::string raw_lut_path("d:/temp/raw_lookup_table/");
-    dump_orthogonal_lut_slices(raw_lut_path);
+    //dump_orthogonal_lut_slices(raw_lut_path);
 
 }
 

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -430,11 +430,13 @@ void GpuBaseAlgorithm::set_scan_sequence(ScanSequence::s_ptr new_scan_sequence) 
     m_num_beams_allocated = static_cast<int>(num_beams);
 }
 
-void GpuBaseAlgorithm::set_analytical_profile(float lateral_sigma, float elevational_sigma) {
+void GpuBaseAlgorithm::set_analytical_profile(IBeamProfile::s_ptr beam_profile) {
+    std::cout << "Setting analytical beam profile for GPU algorithm" << std::endl;
     // TODO: Implement
 }
 
-void GpuBaseAlgorithm::set_lookup_profile() {
+void GpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
+    std::cout << "Setting LUT profile for GPU algorithm" << std::endl;
     // TODO: Implement
 }
 

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -40,7 +40,6 @@ GpuBaseAlgorithm::GpuBaseAlgorithm()
       m_can_change_cuda_device(true),
       m_param_num_cuda_streams(2),
       m_num_time_samples(8192),  // TODO: remove this limitation
-      m_beam_profile(nullptr),
       m_num_beams_allocated(-1),
       m_param_threads_per_block(128),
       m_store_kernel_details(false)
@@ -132,11 +131,7 @@ void GpuBaseAlgorithm::save_cuda_device_properties() {
 }
 
 void GpuBaseAlgorithm::set_beam_profile(IBeamProfile::s_ptr beam_profile) {
-    auto gaussian_profile = std::dynamic_pointer_cast<bcsim::GaussianBeamProfile>(beam_profile);
-    if (!gaussian_profile) {
-        throw std::runtime_error("GPU algorithm currently only supports analytical beam profiles");
-    }
-    m_beam_profile = gaussian_profile;   
+    m_beam_profile = beam_profile;
 }
 
 

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -171,7 +171,7 @@ void GpuBaseAlgorithm::simulate_lines(std::vector<std::vector<std::complex<bc_fl
         throw std::runtime_error("No scanlines in scansequence");
     }
 
-    if (!m_beam_profile_configured) {
+    if (m_cur_beam_profile_type == BeamProfileType::NOT_CONFIGURED) {
         throw std::runtime_error("No beam profile is configured");
     }
     

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -409,7 +409,12 @@ void GpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
 
     std::cout << "Created a new DeviceBeamProfileRAII.\n";
     
-    // Slice the 3D texture and write as RAW file to disk.    
+    const std::string raw_lut_path("d:/temp/raw_lookup_table/");
+    dump_orthogonal_lut_slices(raw_lut_path);
+
+}
+
+void GpuBaseAlgorithm::dump_orthogonal_lut_slices(const std::string& raw_path) {
     const auto write_raw = [&](float3 origin, float3 dir0, float3 dir1, std::string raw_file) {
         const int num_samples = 1024;
         const int total_num_samples = num_samples*num_samples;
@@ -425,7 +430,6 @@ void GpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
         dump_device_buffer_as_raw_file(device_slice, raw_file);
     };
 
-    const std::string raw_path("d:/temp/raw_lookup_table/");
     // slice in the middle lateral-elevational plane (radial dist is 0.5)
     write_raw(make_float3(0.0f, 0.0f, 0.5f),
                 make_float3(1.0f, 0.0f, 0.0f),
@@ -441,6 +445,7 @@ void GpuBaseAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
                 make_float3(0.0f, 1.0f, 0.0f),
                 make_float3(0.0f, 0.0f, 1.0f),
                 raw_path + "lut_slice_ele_rad.raw");
+
 }
 
 }   // end namespace

--- a/src/algorithm/GpuBaseAlgorithm.cu
+++ b/src/algorithm/GpuBaseAlgorithm.cu
@@ -42,7 +42,8 @@ GpuBaseAlgorithm::GpuBaseAlgorithm()
       m_num_time_samples(8192),  // TODO: remove this limitation
       m_num_beams_allocated(-1),
       m_param_threads_per_block(128),
-      m_store_kernel_details(false)
+      m_store_kernel_details(false),
+      m_device_beam_profile(nullptr)
 {
     // ensure that CUDA device properties is stored
     save_cuda_device_properties();

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -52,9 +52,9 @@ public:
     
     virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     override; // TODO: remove
 
-    virtual void set_analytical_profile(float lateral_sigma, float elevational_sigma) override;
+    virtual void set_analytical_profile(IBeamProfile::s_ptr beam_profile) override;
 
-    virtual void set_lookup_profile() override;
+    virtual void set_lookup_profile(IBeamProfile::s_ptr beam_profile) override;
 
 protected:
     void create_cuda_stream_wrappers(int num_streams);

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -50,7 +50,11 @@ public:
 
     virtual void set_excitation(const ExcitationSignal& new_excitation)                 override;
     
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     override;
+    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     override; // TODO: remove
+
+    virtual void set_analytical_profile(float lateral_sigma, float elevational_sigma) override;
+
+    virtual void set_lookup_profile() override;
 
 protected:
     void create_cuda_stream_wrappers(int num_streams);

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -55,6 +55,9 @@ public:
     virtual void set_lookup_profile(IBeamProfile::s_ptr beam_profile) override;
 
 protected:
+    // Debug functionality: slice the 3D texture and write as RAW file to disk.    
+    void GpuBaseAlgorithm::dump_orthogonal_lut_slices(const std::string& raw_path);
+
     void create_cuda_stream_wrappers(int num_streams);
     
     int get_num_cuda_devices() const;

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -50,8 +50,6 @@ public:
 
     virtual void set_excitation(const ExcitationSignal& new_excitation)                 override;
     
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile)                     override; // TODO: remove
-
     virtual void set_analytical_profile(IBeamProfile::s_ptr beam_profile) override;
 
     virtual void set_lookup_profile(IBeamProfile::s_ptr beam_profile) override;
@@ -107,6 +105,18 @@ protected:
 
     // The 3D texture used as lookup-table beam profile.
     DeviceBeamProfileRAII::u_ptr                        m_device_beam_profile;
+
+    // TEMPORARY: Cached analytical profile data
+    float   m_analytical_sigma_lat;
+    float   m_analytical_sigma_ele;
+
+    // TEMPORARY: Cached lookup profile data 
+    float   m_lut_r_min;
+    float   m_lut_r_max;
+    float   m_lut_l_min;
+    float   m_lut_l_max;
+    float   m_lut_e_min;
+    float   m_lut_e_max;
 };
     
 }   // end namespace

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -100,6 +100,9 @@ protected:
 
     // Always reflects the current device in use.
     cudaDeviceProp                                      m_cur_device_prop;
+
+    // The 3D texture used as lookup-table beam profile.
+    DeviceBeamProfileRAII::u_ptr                        m_device_beam_profile;
 };
     
 }   // end namespace

--- a/src/algorithm/GpuBaseAlgorithm.cuh
+++ b/src/algorithm/GpuBaseAlgorithm.cuh
@@ -70,9 +70,6 @@ protected:
     ScanSequence::s_ptr                                 m_scan_seq;
     ExcitationSignal                                    m_excitation;
 
-    // TODO: Figure out how to support LUT beam profiles also.
-    std::shared_ptr<bcsim::GaussianBeamProfile>         m_beam_profile;
-
     // always times equal to the number of scatterers in device memory
     size_t                                              m_num_scatterers;
 

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -194,7 +194,7 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
     
     // Beam profile type determines which kernel to call
     switch(m_cur_beam_profile_type) {
-    case BeamProfile::ANALYTICAL:
+    case BeamProfileType::ANALYTICAL:
         FixedAlgKernel<<<grid_size, block_size, 0, cur_stream>>>(m_device_point_xs->data(),
                                                                  m_device_point_ys->data(),
                                                                  m_device_point_zs->data(),
@@ -215,7 +215,7 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
                                                                  m_excitation.demod_freq);
 
         break;
-    case BeamProfile::LOOKUP:
+    case BeamProfileType::LOOKUP:
         FixedAlgKernel_LUT<<<grid_size, block_size, 0, cur_stream>>>(m_device_point_xs->data(),
                                                                      m_device_point_ys->data(),
                                                                      m_device_point_zs->data(),

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -72,7 +72,7 @@ __global__ void FixedAlgKernel(float* point_xs,
         return;
     }
 
-    float3 point = make_float3(point_xs[global_idx], point_ys[global_idx], point_zs[global_idx]) - origin;
+    const float3 point = make_float3(point_xs[global_idx], point_ys[global_idx], point_zs[global_idx]) - origin;
     
     // compute dot products
     auto radial_dist  = dot(point, rad_dir);

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -124,6 +124,12 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
     dim3 grid_size(num_blocks, 1, 1);
     dim3 block_size(m_param_threads_per_block, 1, 1);
     
+    // HACK: Casting to Gaussian beam profile
+    const auto gaussian_beam_profile = std::dynamic_pointer_cast<bcsim::GaussianBeamProfile>(m_beam_profile);
+    if (!gaussian_beam_profile) {
+        throw std::runtime_error("failed to cast beam profile to a Gaussian beam profile");
+    }
+
     FixedAlgKernel<<<grid_size, block_size, 0, cur_stream>>>(m_device_point_xs->data(),
                                                              m_device_point_ys->data(),
                                                              m_device_point_zs->data(),
@@ -134,8 +140,8 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
                                                              origin,
                                                              m_excitation.sampling_frequency,
                                                              m_num_time_samples,
-                                                             m_beam_profile->getSigmaLateral(),
-                                                             m_beam_profile->getSigmaElevational(),
+                                                             gaussian_beam_profile->getSigmaLateral(),
+                                                             gaussian_beam_profile->getSigmaElevational(),
                                                              m_param_sound_speed,
                                                              m_device_time_proj[stream_no]->data(),
                                                              m_param_use_arc_projection,

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -37,6 +37,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace bcsim {
 
+// Gaussian analytical beam profile.
+__device__ float ComputeWeightAnalytical(float sigma_lateral,
+                                         float sigma_elevational,
+                                         float radial_dist,
+                                         float lateral_dist,
+                                         float elev_dist) {
+    const float two_sigma_lateral_squared     = 2.0f*sigma_lateral*sigma_lateral;
+    const float two_sigma_elevational_squared = 2.0f*sigma_elevational*sigma_elevational; 
+    return expf(-(lateral_dist*lateral_dist/two_sigma_lateral_squared + elev_dist*elev_dist/two_sigma_elevational_squared));
+}
 
 __global__ void FixedAlgKernel(float* point_xs,
                                float* point_ys,
@@ -76,9 +86,7 @@ __global__ void FixedAlgKernel(float* point_xs,
         radial_dist = copysignf(sqrtf(dot(point,point)), radial_dist);
     }
 
-    const float two_sigma_lateral_squared     = 2.0f*sigma_lateral*sigma_lateral;
-    const float two_sigma_elevational_squared = 2.0f*sigma_elevational*sigma_elevational; 
-    const float weight = expf(-(lateral_dist*lateral_dist/two_sigma_lateral_squared + elev_dist*elev_dist/two_sigma_elevational_squared));
+    const float weight = ComputeWeightAnalytical(sigma_lateral, sigma_elevational, radial_dist, lateral_dist, elev_dist);
 
     const int radial_index = static_cast<int>(fs_hertz*2.0f*radial_dist/sound_speed + 0.5f);
     

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -202,7 +202,6 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
     const auto lut_beam_profile      = std::dynamic_pointer_cast<bcsim::LUTBeamProfile>(m_beam_profile);
 
     if (gaussian_beam_profile) {
-        std::cout << "Using FixedAlgKernel\n";
         FixedAlgKernel<<<grid_size, block_size, 0, cur_stream>>>(m_device_point_xs->data(),
                                                                  m_device_point_ys->data(),
                                                                  m_device_point_zs->data(),
@@ -222,7 +221,6 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
                                                                  m_enable_phase_delay,
                                                                  m_excitation.demod_freq);
     } else if (lut_beam_profile) {
-        std::cout << "Using FixedAlgKernel_LUT\n";
         FixedAlgKernel_LUT<<<grid_size, block_size, 0, cur_stream>>>(m_device_point_xs->data(),
                                                                      m_device_point_ys->data(),
                                                                      m_device_point_zs->data(),

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -244,12 +244,15 @@ void GpuFixedAlgorithm::projection_kernel(int stream_no, const Scanline& scanlin
                                                                  m_enable_phase_delay,
                                                                  m_excitation.demod_freq);
     } else if (lut_beam_profile) {
-        const auto lut_r_min = 0.0f; // HACK: using dummy values
-        const auto lut_r_max = 0.12f;
-        const auto lut_l_min = -2e-2f;
-        const auto lut_l_max = 2e-2f;
-        const auto lut_e_min = -2e-2f;
-        const auto lut_e_max = 2e-2;
+        const auto r_range = lut_beam_profile->getRangeRange();
+        const auto l_range = lut_beam_profile->getLateralRange();
+        const auto e_range = lut_beam_profile->getElevationalRange();
+        const auto lut_r_min = r_range.first;
+        const auto lut_r_max = r_range.last;
+        const auto lut_l_min = l_range.first;
+        const auto lut_l_max = l_range.last;
+        const auto lut_e_min = e_range.first;
+        const auto lut_e_max = e_range.last;
 
         FixedAlgKernel_LUT<<<grid_size, block_size, 0, cur_stream>>>(m_device_point_xs->data(),
                                                                      m_device_point_ys->data(),

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -48,6 +48,24 @@ __device__ float ComputeWeightAnalytical(float sigma_lateral,
     return expf(-(lateral_dist*lateral_dist/two_sigma_lateral_squared + elev_dist*elev_dist/two_sigma_elevational_squared));
 }
 
+// 3D texture based lookup-table beam profile.
+__device__ float ComputeWeightLUT(cudaTextureObject_t lut_tex,
+                                  float radial_dist,
+                                  float lateral_dist, 
+                                  float elev_dist,
+                                  float lut_r_min,
+                                  float lut_r_max,
+                                  float lut_l_min,
+                                  float lut_l_max,
+                                  float lut_e_min,
+                                  float lut_e_max
+                                  ) {
+    const auto r_normalized = (radial_dist-lut_r_min)/(lut_r_max-lut_r_min);
+    const auto l_normalized = (lateral_dist-lut_l_min)/(lut_l_max-lut_l_min);
+    const auto e_normalized = (elev_dist-lut_e_min)/(lut_e_max-lut_e_min);
+    return tex3D<float>(lut_tex, l_normalized, e_normalized, r_normalized);
+}
+
 __global__ void FixedAlgKernel(float* point_xs,
                                float* point_ys,
                                float* point_zs,
@@ -155,11 +173,8 @@ __global__ void FixedAlgKernel_LUT(float* point_xs,
     }
 
     // Compute weight from lookup-table and radial_dist, lateral_dist, and elev_dist
-    
-    const auto r_normalized = (radial_dist-lut_r_min)/(lut_r_max-lut_r_min);
-    const auto l_normalized = (lateral_dist-lut_l_min)/(lut_l_max-lut_l_min);
-    const auto e_normalized = (elev_dist-lut_e_min)/(lut_e_max-lut_e_min);
-    const auto weight = tex3D<float>(lut_tex, l_normalized, e_normalized, r_normalized);
+    const auto weight = ComputeWeightLUT(lut_tex, radial_dist, lateral_dist, elev_dist,
+                                         lut_r_min, lut_r_max, lut_l_min, lut_l_max, lut_e_min, lut_e_max);
 
     const int radial_index = static_cast<int>(fs_hertz*2.0f*radial_dist/sound_speed + 0.5f);
     

--- a/src/algorithm/GpuFixedAlgorithm.cu
+++ b/src/algorithm/GpuFixedAlgorithm.cu
@@ -37,34 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace bcsim {
 
-// Gaussian analytical beam profile.
-__device__ float ComputeWeightAnalytical(float sigma_lateral,
-                                         float sigma_elevational,
-                                         float radial_dist,
-                                         float lateral_dist,
-                                         float elev_dist) {
-    const float two_sigma_lateral_squared     = 2.0f*sigma_lateral*sigma_lateral;
-    const float two_sigma_elevational_squared = 2.0f*sigma_elevational*sigma_elevational; 
-    return expf(-(lateral_dist*lateral_dist/two_sigma_lateral_squared + elev_dist*elev_dist/two_sigma_elevational_squared));
-}
-
-// 3D texture based lookup-table beam profile.
-__device__ float ComputeWeightLUT(cudaTextureObject_t lut_tex,
-                                  float radial_dist,
-                                  float lateral_dist, 
-                                  float elev_dist,
-                                  float lut_r_min,
-                                  float lut_r_max,
-                                  float lut_l_min,
-                                  float lut_l_max,
-                                  float lut_e_min,
-                                  float lut_e_max
-                                  ) {
-    const auto r_normalized = (radial_dist-lut_r_min)/(lut_r_max-lut_r_min);
-    const auto l_normalized = (lateral_dist-lut_l_min)/(lut_l_max-lut_l_min);
-    const auto e_normalized = (elev_dist-lut_e_min)/(lut_e_max-lut_e_min);
-    return tex3D<float>(lut_tex, l_normalized, e_normalized, r_normalized);
-}
 
 __global__ void FixedAlgKernel(float* point_xs,
                                float* point_ys,

--- a/src/algorithm/GpuSplineAlgorithm1.cuh
+++ b/src/algorithm/GpuSplineAlgorithm1.cuh
@@ -69,12 +69,12 @@ public:
         return m_fixed_alg->get_debug_data(identifier);
     }
 
-    virtual void set_analytical_profile(float lateral_sigma, float elevational_sigma) override {
-        m_fixed_alg->set_analytical_profile(lateral_sigma, elevational_sigma);
+    virtual void set_analytical_profile(IBeamProfile::s_ptr beam_profile) override {
+        m_fixed_alg->set_analytical_profile(beam_profile);
     }
 
-    virtual void set_lookup_profile() override {
-        m_fixed_alg->set_lookup_profile();
+    virtual void set_lookup_profile(IBeamProfile::s_ptr beam_profile) override {
+        m_fixed_alg->set_lookup_profile(beam_profile);
     }
     
 private:

--- a/src/algorithm/GpuSplineAlgorithm1.cuh
+++ b/src/algorithm/GpuSplineAlgorithm1.cuh
@@ -59,7 +59,7 @@ public:
         m_fixed_alg->set_excitation(new_excitation);
     }
 
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override {
+    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override { // TODO: remove
         m_fixed_alg->set_beam_profile(beam_profile);
     }
 

--- a/src/algorithm/GpuSplineAlgorithm1.cuh
+++ b/src/algorithm/GpuSplineAlgorithm1.cuh
@@ -59,10 +59,6 @@ public:
         m_fixed_alg->set_excitation(new_excitation);
     }
 
-    virtual void set_beam_profile(IBeamProfile::s_ptr beam_profile) override { // TODO: remove
-        m_fixed_alg->set_beam_profile(beam_profile);
-    }
-
     virtual void simulate_lines(std::vector<std::vector<std::complex<bc_float>> >&  /*out*/ rf_lines) override;
 
     std::vector<double> get_debug_data(const std::string& identifier) const override {

--- a/src/algorithm/GpuSplineAlgorithm1.cuh
+++ b/src/algorithm/GpuSplineAlgorithm1.cuh
@@ -68,6 +68,14 @@ public:
     std::vector<double> get_debug_data(const std::string& identifier) const override {
         return m_fixed_alg->get_debug_data(identifier);
     }
+
+    virtual void set_analytical_profile(float lateral_sigma, float elevational_sigma) override {
+        m_fixed_alg->set_analytical_profile(lateral_sigma, elevational_sigma);
+    }
+
+    virtual void set_lookup_profile() override {
+        m_fixed_alg->set_lookup_profile();
+    }
     
 private:
     // Test if all scanlines in a scan sequence have the same timestamp

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -289,7 +289,31 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
                                                                   m_excitation.demod_freq);
         break;
     case BeamProfileType::LOOKUP:
-        throw std::runtime_error("GpuSplineAlgorithm2 currently only supports analytical beam profile");
+        SplineAlgKernel_LUT<<<grid_size, block_size, 0, cur_stream>>>(m_device_control_xs->data(),
+                                                                      m_device_control_ys->data(),
+                                                                      m_device_control_zs->data(),
+                                                                      m_device_control_as->data(),
+                                                                      rad_dir,
+                                                                      lat_dir,
+                                                                      ele_dir,
+                                                                      origin,
+                                                                      m_excitation.sampling_frequency,
+                                                                      m_num_time_samples,
+                                                                      m_param_sound_speed,
+                                                                      m_num_cs,
+                                                                      m_num_splines,
+                                                                      m_device_time_proj[stream_no]->data(),
+                                                                      eval_basis_offset_elements,
+                                                                      m_param_use_arc_projection,
+                                                                      m_enable_phase_delay,
+                                                                      m_excitation.demod_freq,
+                                                                      m_device_beam_profile->get(),
+                                                                      m_lut_r_min,
+                                                                      m_lut_r_max,
+                                                                      m_lut_l_min,
+                                                                      m_lut_l_max,
+                                                                      m_lut_e_min,
+                                                                      m_lut_e_max);
         break;
     default:
         throw std::logic_error("GpuSplineAlgorithm2: unknown beam profile type");

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -177,10 +177,8 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
     // TODO: Is it neccessary to have both m_num_splines AND m_num_scatterers? They
     // are equal...
 
-    // HACK: Casting to Gaussian beam profile
-    const auto gaussian_beam_profile = std::dynamic_pointer_cast<bcsim::GaussianBeamProfile>(m_beam_profile);
-    if (!gaussian_beam_profile) {
-        throw std::runtime_error("failed to cast beam profile to a Gaussian beam profile");
+    if (m_cur_beam_profile_type != BeamProfile::ANALYTICAL) {
+        throw std::runtime_error("GpuSplineAlgorithm2 currently only supports analytical beam profile");
     }
 
     // do the time-projections
@@ -194,8 +192,8 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
                                                               origin,
                                                               m_excitation.sampling_frequency,
                                                               m_num_time_samples,
-                                                              gaussian_beam_profile->getSigmaLateral(),
-                                                              gaussian_beam_profile->getSigmaElevational(),
+                                                              m_analytical_sigma_lat,
+                                                              m_analytical_sigma_ele,
                                                               m_param_sound_speed,
                                                               m_num_cs,
                                                               m_num_splines,

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -177,7 +177,7 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
     // TODO: Is it neccessary to have both m_num_splines AND m_num_scatterers? They
     // are equal...
 
-    if (m_cur_beam_profile_type != BeamProfile::ANALYTICAL) {
+    if (m_cur_beam_profile_type != BeamProfileType::ANALYTICAL) {
         throw std::runtime_error("GpuSplineAlgorithm2 currently only supports analytical beam profile");
     }
 

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -177,32 +177,35 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
     // TODO: Is it neccessary to have both m_num_splines AND m_num_scatterers? They
     // are equal...
 
-    if (m_cur_beam_profile_type != BeamProfileType::ANALYTICAL) {
+    switch (m_cur_beam_profile_type) {
+    case BeamProfileType::ANALYTICAL:
+        SplineAlgKernel<<<grid_size, block_size, 0, cur_stream>>>(m_device_control_xs->data(),
+                                                                  m_device_control_ys->data(),
+                                                                  m_device_control_zs->data(),
+                                                                  m_device_control_as->data(),
+                                                                  rad_dir,
+                                                                  lat_dir,
+                                                                  ele_dir,
+                                                                  origin,
+                                                                  m_excitation.sampling_frequency,
+                                                                  m_num_time_samples,
+                                                                  m_analytical_sigma_lat,
+                                                                  m_analytical_sigma_ele,
+                                                                  m_param_sound_speed,
+                                                                  m_num_cs,
+                                                                  m_num_splines,
+                                                                  m_device_time_proj[stream_no]->data(),
+                                                                  eval_basis_offset_elements,
+                                                                  m_param_use_arc_projection,
+                                                                  m_enable_phase_delay,
+                                                                  m_excitation.demod_freq);
+        break;
+    case BeamProfileType::LOOKUP:
         throw std::runtime_error("GpuSplineAlgorithm2 currently only supports analytical beam profile");
+        break;
+    default:
+        throw std::logic_error("GpuSplineAlgorithm2: unknown beam profile type");
     }
-
-    // do the time-projections
-    SplineAlgKernel<<<grid_size, block_size, 0, cur_stream>>>(m_device_control_xs->data(),
-                                                              m_device_control_ys->data(),
-                                                              m_device_control_zs->data(),
-                                                              m_device_control_as->data(),
-                                                              rad_dir,
-                                                              lat_dir,
-                                                              ele_dir,
-                                                              origin,
-                                                              m_excitation.sampling_frequency,
-                                                              m_num_time_samples,
-                                                              m_analytical_sigma_lat,
-                                                              m_analytical_sigma_ele,
-                                                              m_param_sound_speed,
-                                                              m_num_cs,
-                                                              m_num_splines,
-                                                              m_device_time_proj[stream_no]->data(),
-                                                              eval_basis_offset_elements,
-                                                              m_param_use_arc_projection,
-                                                              m_enable_phase_delay,
-                                                              m_excitation.demod_freq);
-
 }
 
 void GpuSplineAlgorithm2::copy_scatterers_to_device(SplineScatterers::s_ptr scatterers) {

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -100,10 +100,7 @@ __global__ void SplineAlgKernel(float* control_xs,
         radial_dist = copysignf(sqrtf(dot(point,point)), radial_dist);
     }
 
-    // compute weight
-    const float two_sigma_lateral_squared     = 2.0f*sigma_lateral*sigma_lateral;
-    const float two_sigma_elevational_squared = 2.0f*sigma_elevational*sigma_elevational; 
-    const float weight = expf(-(lateral_dist*lateral_dist/two_sigma_lateral_squared + elev_dist*elev_dist/two_sigma_elevational_squared));
+    const float weight = ComputeWeightAnalytical(sigma_lateral, sigma_elevational, radial_dist, lateral_dist, elev_dist);
 
     const int radial_index = static_cast<int>(fs_hertz*2.0f*radial_dist/sound_speed + 0.5f);
     

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -180,6 +180,12 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
     // TODO: Is it neccessary to have both m_num_splines AND m_num_scatterers? They
     // are equal...
 
+    // HACK: Casting to Gaussian beam profile
+    const auto gaussian_beam_profile = std::dynamic_pointer_cast<bcsim::GaussianBeamProfile>(m_beam_profile);
+    if (!gaussian_beam_profile) {
+        throw std::runtime_error("failed to cast beam profile to a Gaussian beam profile");
+    }
+
     // do the time-projections
     SplineAlgKernel<<<grid_size, block_size, 0, cur_stream>>>(m_device_control_xs->data(),
                                                               m_device_control_ys->data(),
@@ -191,8 +197,8 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
                                                               origin,
                                                               m_excitation.sampling_frequency,
                                                               m_num_time_samples,
-                                                              m_beam_profile->getSigmaLateral(),
-                                                              m_beam_profile->getSigmaElevational(),
+                                                              gaussian_beam_profile->getSigmaLateral(),
+                                                              gaussian_beam_profile->getSigmaElevational(),
                                                               m_param_sound_speed,
                                                               m_num_cs,
                                                               m_num_splines,

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -125,6 +125,94 @@ __global__ void SplineAlgKernel(float* control_xs,
     }
 }
 
+__global__ void SplineAlgKernel_LUT(float* control_xs,
+                                    float* control_ys,
+                                    float* control_zs,
+                                    float* control_as,
+                                    float3 rad_dir,
+                                    float3 lat_dir,
+                                    float3 ele_dir,
+                                    float3 origin,
+                                    float  fs_hertz,
+                                    int    num_time_samples,
+                                    float  sound_speed,
+                                    int    NUM_CS,
+                                    int    NUM_SPLINES,
+                                    cuComplex* res,
+                                    size_t eval_basis_offset_elements,
+                                    bool   use_arc_projection,
+                                    bool   use_phase_delay,
+                                    float  demod_freq,
+                                    cudaTextureObject_t lut_tex,
+                                    float lut_r_min,
+                                    float lut_r_max,
+                                    float lut_l_min,
+                                    float lut_l_max,
+                                    float lut_e_min,
+                                    float lut_e_max) {
+
+    const int global_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    if (global_idx >= NUM_SPLINES) {
+        return;
+    }
+
+    // step 1: evaluate spline
+    // to get from one control point to the next, we have
+    // to make a jump of size equal to number of splines
+    float rendered_x = 0.0f;
+    float rendered_y = 0.0f;
+    float rendered_z = 0.0f;
+    float rendered_a = 0.0f;
+    for (int i = 0; i < NUM_CS; i++) {
+        size_t eval_basis_i = i + eval_basis_offset_elements;
+        rendered_x += control_xs[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
+        rendered_y += control_ys[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
+        rendered_z += control_zs[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
+        rendered_a += control_as[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
+    }
+
+    // step 2: compute projections
+    float3 point = make_float3(rendered_x, rendered_y, rendered_z) - origin;
+    
+    // compute dot products
+    auto radial_dist  = dot(point, rad_dir);
+    const auto lateral_dist = dot(point, lat_dir);
+    const auto elev_dist    = dot(point, ele_dir);
+
+    if (use_arc_projection) {
+        // Use "arc projection" in the radial direction: use length of vector from
+        // beam's origin to the scatterer with the same sign as the projection onto
+        // the line.
+        radial_dist = copysignf(sqrtf(dot(point,point)), radial_dist);
+    }
+
+    // Compute weight from lookup-table and radial_dist, lateral_dist, and elev_dist
+    const auto weight = ComputeWeightLUT(lut_tex, radial_dist, lateral_dist, elev_dist,
+                                         lut_r_min, lut_r_max, lut_l_min, lut_l_max, lut_e_min, lut_e_max);
+
+    const int radial_index = static_cast<int>(fs_hertz*2.0f*radial_dist/sound_speed + 0.5f);
+    
+    if (radial_index >= 0 && radial_index < num_time_samples) {
+        //atomicAdd(res+radial_index, weight*rendered_a);
+        if (use_phase_delay) {
+            // handle sub-sample displacement with a complex phase
+            const auto true_index = fs_hertz*2.0f*radial_dist/sound_speed;
+            const float ss_delay = (radial_index - true_index)/fs_hertz;
+            const float complex_phase = 6.283185307179586*demod_freq*ss_delay;
+
+            // exp(i*theta) = cos(theta) + i*sin(theta)
+            float sin_value, cos_value;
+            sincosf(complex_phase, &sin_value, &cos_value);
+
+            const auto w = weight*rendered_a;
+            atomicAdd(&(res[radial_index].x), w*cos_value);
+            atomicAdd(&(res[radial_index].y), w*sin_value);
+        } else {
+            atomicAdd(&(res[radial_index].x), weight*rendered_a);
+        }
+    }
+}
+
 
 namespace bcsim {
 

--- a/src/algorithm/cuda_debug_utils.h
+++ b/src/algorithm/cuda_debug_utils.h
@@ -33,4 +33,5 @@ void dump_device_buffer_as_raw_file(DeviceBufferRAII<T>& device_buffer, const st
     }
 
     out_stream.close();
+    std::cout << "Wrote RAW file to " << raw_file << std::endl;
 }

--- a/src/algorithm/cuda_debug_utils.h
+++ b/src/algorithm/cuda_debug_utils.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <cuda.h>
+#include "cuda_helpers.h"
+
+template <typename T>
+void dump_device_buffer_as_raw_file(DeviceBufferRAII<T>& device_buffer, const std::string& raw_file, bool normalize_uchar8=true) {
+    const auto num_bytes = device_buffer.get_num_bytes();
+    const auto num_elements = num_bytes/sizeof(T);
+    std::vector<T> host_buffer(num_elements);
+    cudaErrorCheck( cudaMemcpy(host_buffer.data(), device_buffer.data(), num_bytes, cudaMemcpyDeviceToHost) );
+    cudaErrorCheck( cudaDeviceSynchronize() );
+
+    std::ofstream out_stream;
+    out_stream.open(raw_file, std::ios::binary | std::ios::out);
+
+    if (normalize_uchar8) {
+        const auto min_val = *std::min_element(std::begin(host_buffer), std::end(host_buffer));
+        const auto max_val = *std::max_element(std::begin(host_buffer), std::end(host_buffer));
+
+        std::vector<unsigned char> temp(num_elements);
+        std::transform(std::begin(host_buffer), std::end(host_buffer), std::begin(temp), [=](float v) {
+            return static_cast<unsigned char>(255.0*(v-min_val)/(max_val-min_val));
+        });
+        out_stream.write(reinterpret_cast<const char*>(temp.data()), num_elements*sizeof(unsigned char));
+
+    } else {
+        out_stream.write(reinterpret_cast<const char*>(host_buffer.data()), num_bytes);
+    }
+
+    out_stream.close();
+}

--- a/src/algorithm/cuda_helpers.h
+++ b/src/algorithm/cuda_helpers.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <random>
 #include <driver_types.h>
+#include <driver_functions.h>
 #include <cuda_runtime_api.h>
 #include <vector_functions.h>   // for make_float3() etc.
 
@@ -184,3 +185,70 @@ void fill_host_vector_uniform_random(T low, T high, size_t length, T* data) {
 inline int round_up_div(int num, int den) {
     return static_cast<int>(std::ceil(static_cast<float>(num)/den));
 }
+
+// 3D texture with tri-linear interpolation.
+class DeviceBeamProfileRAII {
+public:
+    typedef struct TableExtent3D {
+        TableExtent3D() : lateral(0), elevational(0), radial(0) { }
+        TableExtent3D(size_t num_samples_lat, size_t num_samples_ele, size_t num_samples_rad)
+            : lateral(num_samples_lat), elevational(num_samples_ele), radial(num_samples_rad) { }
+        size_t lateral;
+        size_t elevational;
+        size_t radial;
+    } TableExtent3D;
+
+    DeviceBeamProfileRAII(const TableExtent3D& table_extent, std::vector<float>& host_input_buffer)
+        : texture_object(0)
+    {
+        auto channel_desc = cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
+        cudaExtent extent = make_cudaExtent(table_extent.lateral, table_extent.elevational, table_extent.radial);
+        cudaErrorCheck( cudaMalloc3DArray(&cu_array_3d, &channel_desc, extent, 0) );
+        std::cout << "DeviceBeamProfileRAII: Allocated 3D array\n";
+        
+        // copy input data from host to CUDA 3D array
+        cudaMemcpy3DParms par_3d = {0};
+        par_3d.srcPtr = make_cudaPitchedPtr(host_input_buffer.data(), table_extent.lateral*sizeof(float), table_extent.lateral, table_extent.elevational); 
+        par_3d.dstArray = cu_array_3d;
+        par_3d.extent = extent;
+        par_3d.kind = cudaMemcpyHostToDevice;
+        cudaErrorCheck( cudaMemcpy3D(&par_3d) );
+        std::cout << "DeviceBeamProfileRAII: Copied memory to device\n";
+
+        // specify texture
+        cudaResourceDesc res_desc;
+        memset(&res_desc, 0, sizeof(res_desc));
+        res_desc.resType = cudaResourceTypeArray;
+        res_desc.res.array.array = cu_array_3d;
+
+        // specify texture object parameters
+        cudaTextureDesc tex_desc;
+        memset(&tex_desc, 0, sizeof(tex_desc));
+        tex_desc.normalizedCoords = 1;
+        tex_desc.filterMode = cudaFilterModeLinear;
+
+        // use border to pad with zeros outsize
+        tex_desc.addressMode[0] = cudaAddressModeBorder;
+        tex_desc.addressMode[1] = cudaAddressModeBorder;
+        tex_desc.addressMode[2] = cudaAddressModeBorder;
+        tex_desc.readMode = cudaReadModeElementType;
+
+        cudaErrorCheck( cudaCreateTextureObject(&texture_object, &res_desc, &tex_desc, NULL) );
+        std::cout << "DeviceBeamProfileRAII: Created texture object.\n";
+    }
+
+    cudaTextureObject_t get() {
+        return texture_object;
+    }
+
+    ~DeviceBeamProfileRAII() {
+        cudaErrorCheck( cudaDestroyTextureObject(texture_object) );
+        std::cout << "DeviceBeamProfileRAII: Destroyed texture object\n";
+        cudaErrorCheck( cudaFreeArray(cu_array_3d) );
+        std::cout << "DeviceBeamProfileRAII: Freed 3D array\n";
+    }
+
+private:
+    cudaTextureObject_t     texture_object;
+    cudaArray*              cu_array_3d;
+};

--- a/src/algorithm/cuda_helpers.h
+++ b/src/algorithm/cuda_helpers.h
@@ -189,6 +189,9 @@ inline int round_up_div(int num, int den) {
 // 3D texture with tri-linear interpolation.
 class DeviceBeamProfileRAII {
 public:
+    typedef std::unique_ptr<DeviceBeamProfileRAII> u_ptr;
+    typedef std::shared_ptr<DeviceBeamProfileRAII> s_ptr;
+
     typedef struct TableExtent3D {
         TableExtent3D() : lateral(0), elevational(0), radial(0) { }
         TableExtent3D(size_t num_samples_lat, size_t num_samples_ele, size_t num_samples_rad)

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -22,4 +22,11 @@ if (BCSIM_ENABLE_CUDA)
     target_link_libraries(gpu_texture_example
                           ${CUDA_LIBRARIES}
                           )
+    cuda_add_executable(gpu_3d_texture_example
+                        gpu_3d_texture_example.cu
+                        ../algorithm/cuda_helpers.h
+                        )
+    target_link_libraries(gpu_3d_texture_example
+                          ${CUDA_LIBRARIES}
+                         )
 endif()

--- a/src/benchmark/gpu_3d_texture_example.cu
+++ b/src/benchmark/gpu_3d_texture_example.cu
@@ -1,78 +1,148 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <iostream>
+#include <fstream>
 #include "algorithm/cuda_helpers.h"
 #include "device_launch_parameters.h"
 
-__global__ void tex_kernel(cudaTextureObject_t texture_obj, int num_samples, float* output) {
+// Sample in xy plane (at a constant z)
+__global__ void tex_kernel(cudaTextureObject_t texture_obj,
+                           float x_min_normalized,
+                           float x_max_normalized,
+                           float y_min_normalized,
+                           float y_max_normalized,
+                           float z_normalized,
+                           int samples,     // resolution of sampling in x and y
+                           float* output    // where to store output (must be size samples*samples)
+                           ) {
     unsigned int idx = blockIdx.x*blockDim.x + threadIdx.x;
-    if (idx < num_samples) {
-        float u = idx / static_cast<float>(num_samples);
-        output[idx] = tex1D<float>(texture_obj, u);
+    if (idx == 0) {
+        // do all work in first thread
+        for (int xi = 0; xi < samples; xi++) {
+            for (int yi = 0; yi < samples; yi++) {
+                const auto x_normalized = x_min_normalized + xi*(x_max_normalized-x_min_normalized)/(samples-1);
+                const auto y_normalized = y_min_normalized + yi*(y_max_normalized-y_min_normalized)/(samples-1);
+
+                const auto tex_value = tex3D<float>(texture_obj, x_normalized, y_normalized, z_normalized);
+                //printf("Tex3d @ (%f, %f, %f) = %f\n", x_normalized, y_normalized, z_normalized, tex_value);
+                output[xi + samples*yi] = tex_value;
+            }
+        }
     }
 }
 
 int main() {
-    std::cout << "Demo: use CUDA textures for linear interpolation of 1D signal" << std::endl;
-    const size_t num_output_samples = 1024;
-    const size_t num_input_samples = 128;
-    
-    // create data to be interpolated
-    std::vector<float> host_input_buffer(num_input_samples);
-    for (size_t i = 0; i < num_input_samples; i++) {
-        host_input_buffer[i] = i*1.0f;
+    std::cout << "Demo: use CUDA 3D textures for linear interpolation" << std::endl;
+    const size_t num_samples_x = 32;   // aka. width
+    const size_t num_samples_y = 32;   // aka. height
+    const size_t num_samples_z = 1024;  // aka. depth
+
+    const auto x_min = -2e-2;
+    const auto x_max = 2e-2;
+    const auto y_min = -2e-2;
+    const auto y_max = 2e-2;
+    const auto z_min = 0.0;
+    const auto z_max = 8e-2;
+
+    // radius
+    const auto r_min = 5e-3;        // at z_min
+    const auto r_max = 13e-3;       // at z_max
+
+    // create data to be interpolated - Gaussian cylinder
+    std::vector<float> host_input_buffer;
+    const auto num_total = num_samples_x*num_samples_y*num_samples_z;
+    host_input_buffer.reserve(num_total);
+    for (size_t zi = 0; zi < num_samples_z; zi++) {
+        for (size_t yi = 0; yi < num_samples_y; yi++) {
+            for (size_t xi = 0; xi < num_samples_x; xi++) {
+                const auto x = x_min + xi*(x_max-x_min)/(num_samples_x-1);
+                const auto y = y_min + yi*(y_max-y_min)/(num_samples_y-1);
+                //const auto z = z_min + zi*(z_max-z_min)/(num_samples_z-1);
+                const auto r = r_min + zi*(r_max-r_min)/(num_samples_z-1);
+                //size_t index = num_samples_y*num_samples_z*xi + num_samples_x*yi + zi; // ????
+                host_input_buffer.push_back( std::exp(-(x*x + y*y)/(r*r)) );
+            }
+        }
     }
-
-    // allocate CUDA array in device memory
+    
+    // allocate CUDA 3D array in device memory
+    // channelDesc describes the format of the value returned when fetching the texture
+    // ==> float texels (32, 0, 0, 0)
     auto channel_desc = cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
-    cudaArray* cu_array;
-    cudaErrorCheck( cudaMallocArray(&cu_array, &channel_desc, num_input_samples) );
-    const size_t num_input_bytes = sizeof(float)*num_input_samples;
+    cudaArray* cu_array_3d;
+    
+    // Stackoverflow:
+    //  Because you are allocating an array with cudaMalloc3DArray, use the width in elements.
+    //  If you were using cudaMalloc3D, the extent would have a width in bytes
+    //
+    // Also: "The documentation says that if the transfer doesn't include cuda arrays, then the width parameter is always the width in bytes!".
+    cudaExtent extent = make_cudaExtent(num_samples_x, num_samples_y, num_samples_z);
+    cudaErrorCheck( cudaMalloc3DArray(&cu_array_3d, &channel_desc, extent, 0) );
 
-    // copy input data from host to CUDA array
-    cudaErrorCheck( cudaMemcpyToArray(cu_array, 0, 0, host_input_buffer.data(), num_input_bytes, cudaMemcpyHostToDevice) );
-
+    // copy input data from host to CUDA 3D array
+    cudaMemcpy3DParms par_3d = {0};
+    par_3d.srcPtr = make_cudaPitchedPtr(host_input_buffer.data(), num_samples_x*sizeof(float), num_samples_x, num_samples_y); 
+    par_3d.dstArray = cu_array_3d;
+    par_3d.extent = extent;
+    par_3d.kind = cudaMemcpyHostToDevice;
+    cudaErrorCheck( cudaMemcpy3D(&par_3d) );
 
     // specify texture
     cudaResourceDesc res_desc;
     memset(&res_desc, 0, sizeof(res_desc));
     res_desc.resType = cudaResourceTypeArray;
-    res_desc.res.array.array = cu_array;
+    res_desc.res.array.array = cu_array_3d;
 
     // specify texture object parameters
     cudaTextureDesc tex_desc;
-    memset(&tex_desc, 0, sizeof(cudaTextureDesc));
-    tex_desc.addressMode[0] = cudaAddressModeClamp;
-    tex_desc.filterMode = cudaFilterModeLinear;
-    tex_desc.readMode = cudaReadModeElementType;
+    memset(&tex_desc, 0, sizeof(tex_desc));
     tex_desc.normalizedCoords = 1;
+    tex_desc.filterMode = cudaFilterModeLinear;
+    //tex_desc.filterMode = cudaFilterModePoint;
+
+    // use border to pad with zeros outsize
+    tex_desc.addressMode[0] = cudaAddressModeBorder;
+    tex_desc.addressMode[1] = cudaAddressModeBorder;
+    tex_desc.addressMode[2] = cudaAddressModeBorder;
+    tex_desc.readMode = cudaReadModeElementType;
 
     // create texture object
     cudaTextureObject_t tex_obj = 0;
     cudaCreateTextureObject(&tex_obj, &res_desc, &tex_desc, NULL);
 
+
+    int samples = 2048; // sampling res in kernel
+    const auto num_output_samples = samples*samples;
+
     // device buffer to hold output data
     const size_t num_output_bytes = sizeof(float)*num_output_samples;
     DeviceBufferRAII<float> device_output_buffer(num_output_bytes);
 
-    // launch kernel
-    dim3 block(128, 1, 1);
-    dim3 grid(num_output_samples/block.x, 1, 1);
-    tex_kernel<<<grid, block>>>(tex_obj, num_output_samples, device_output_buffer.data());
+    // launch kernel - just one thread
+    const auto z_normalized = 0.5f;
+    dim3 block(1, 1, 1);
+    dim3 grid(1, 1, 1);
+    const auto pad = 0.25f;
+    tex_kernel<<<grid, block>>>(tex_obj, 0.0f-pad, 1.0f+pad, 0.0f-pad, 1.0f+pad, z_normalized, samples, device_output_buffer.data());
     cudaErrorCheck( cudaDeviceSynchronize() );
 
     // copy result to host buffer
     std::vector<float> host_output_buffer(num_output_samples);
     cudaErrorCheck( cudaMemcpy(host_output_buffer.data(), device_output_buffer.data(), num_output_bytes, cudaMemcpyDeviceToHost) );
 
-
     cudaErrorCheck( cudaDestroyTextureObject(tex_obj) );
-    cudaErrorCheck( cudaFreeArray(cu_array) );
+    cudaErrorCheck( cudaFreeArray(cu_array_3d) );
 
-    // print results
+    // map to [0, 255] and store as uchar8
+    std::vector<unsigned char> bytes(num_output_samples);
     for (size_t i = 0; i < num_output_samples; i++) {
-        std::cout << i << " : " << host_output_buffer[i] << std::endl;
+        bytes[i] = static_cast<unsigned char>(host_output_buffer[i]*255);
     }
+
+    std::ofstream out;
+    out.open("d:/temp/tex3d_out.raw", std::ios::binary | std::ios::out);
+    out.write(reinterpret_cast<const char*>(bytes.data()), num_output_samples);
+    out.close();
 
     return 0;
 }

--- a/src/benchmark/gpu_3d_texture_example.cu
+++ b/src/benchmark/gpu_3d_texture_example.cu
@@ -108,7 +108,7 @@ int main() {
 
     // create texture object
     cudaTextureObject_t tex_obj = 0;
-    cudaCreateTextureObject(&tex_obj, &res_desc, &tex_desc, NULL);
+    cudaErrorCheck( cudaCreateTextureObject(&tex_obj, &res_desc, &tex_desc, NULL) );
 
 
     int samples = 2048; // sampling res in kernel

--- a/src/benchmark/gpu_3d_texture_example.cu
+++ b/src/benchmark/gpu_3d_texture_example.cu
@@ -1,0 +1,78 @@
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <iostream>
+#include "algorithm/cuda_helpers.h"
+#include "device_launch_parameters.h"
+
+__global__ void tex_kernel(cudaTextureObject_t texture_obj, int num_samples, float* output) {
+    unsigned int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    if (idx < num_samples) {
+        float u = idx / static_cast<float>(num_samples);
+        output[idx] = tex1D<float>(texture_obj, u);
+    }
+}
+
+int main() {
+    std::cout << "Demo: use CUDA textures for linear interpolation of 1D signal" << std::endl;
+    const size_t num_output_samples = 1024;
+    const size_t num_input_samples = 128;
+    
+    // create data to be interpolated
+    std::vector<float> host_input_buffer(num_input_samples);
+    for (size_t i = 0; i < num_input_samples; i++) {
+        host_input_buffer[i] = i*1.0f;
+    }
+
+    // allocate CUDA array in device memory
+    auto channel_desc = cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
+    cudaArray* cu_array;
+    cudaErrorCheck( cudaMallocArray(&cu_array, &channel_desc, num_input_samples) );
+    const size_t num_input_bytes = sizeof(float)*num_input_samples;
+
+    // copy input data from host to CUDA array
+    cudaErrorCheck( cudaMemcpyToArray(cu_array, 0, 0, host_input_buffer.data(), num_input_bytes, cudaMemcpyHostToDevice) );
+
+
+    // specify texture
+    cudaResourceDesc res_desc;
+    memset(&res_desc, 0, sizeof(res_desc));
+    res_desc.resType = cudaResourceTypeArray;
+    res_desc.res.array.array = cu_array;
+
+    // specify texture object parameters
+    cudaTextureDesc tex_desc;
+    memset(&tex_desc, 0, sizeof(cudaTextureDesc));
+    tex_desc.addressMode[0] = cudaAddressModeClamp;
+    tex_desc.filterMode = cudaFilterModeLinear;
+    tex_desc.readMode = cudaReadModeElementType;
+    tex_desc.normalizedCoords = 1;
+
+    // create texture object
+    cudaTextureObject_t tex_obj = 0;
+    cudaCreateTextureObject(&tex_obj, &res_desc, &tex_desc, NULL);
+
+    // device buffer to hold output data
+    const size_t num_output_bytes = sizeof(float)*num_output_samples;
+    DeviceBufferRAII<float> device_output_buffer(num_output_bytes);
+
+    // launch kernel
+    dim3 block(128, 1, 1);
+    dim3 grid(num_output_samples/block.x, 1, 1);
+    tex_kernel<<<grid, block>>>(tex_obj, num_output_samples, device_output_buffer.data());
+    cudaErrorCheck( cudaDeviceSynchronize() );
+
+    // copy result to host buffer
+    std::vector<float> host_output_buffer(num_output_samples);
+    cudaErrorCheck( cudaMemcpy(host_output_buffer.data(), device_output_buffer.data(), num_output_bytes, cudaMemcpyDeviceToHost) );
+
+
+    cudaErrorCheck( cudaDestroyTextureObject(tex_obj) );
+    cudaErrorCheck( cudaFreeArray(cu_array) );
+
+    // print results
+    for (size_t i = 0; i < num_output_samples; i++) {
+        std::cout << i << " : " << host_output_buffer[i] << std::endl;
+    }
+
+    return 0;
+}

--- a/src/examples/bcsim_demo.cpp
+++ b/src/examples/bcsim_demo.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
     // Either analytical or lookup table.
     IBeamProfile::s_ptr beam_profile;
     beam_profile = IBeamProfile::s_ptr(new GaussianBeamProfile(0.2e-3, 0.2e-3));
-    simulator->set_beam_profile(beam_profile);
+    simulator->set_analytical_profile(beam_profile);
     
     try {
         if (runLoop) {

--- a/src/examples/gpu_example1.cpp
+++ b/src/examples/gpu_example1.cpp
@@ -97,7 +97,7 @@ void example(int argc, char** argv) {
     sim->set_parameter("verbose", "0");
     
     // use an analytical Gaussian beam profile
-    sim->set_beam_profile(bcsim::IBeamProfile::s_ptr(new bcsim::GaussianBeamProfile(1e-3, 3e-3)));
+    sim->set_analytical_profile(bcsim::IBeamProfile::s_ptr(new bcsim::GaussianBeamProfile(1e-3, 3e-3)));
 
     // configure the excitation signal
     const auto fs          = 100e6f;

--- a/src/examples/gpu_example2.cpp
+++ b/src/examples/gpu_example2.cpp
@@ -91,7 +91,7 @@ void example(int argc, char** argv) {
     sim->set_parameter("verbose", "0");
     
     // use an analytical Gaussian beam profile
-    sim->set_beam_profile(bcsim::IBeamProfile::s_ptr(new bcsim::GaussianBeamProfile(1e-3, 3e-3)));
+    sim->set_analytical_profile(bcsim::IBeamProfile::s_ptr(new bcsim::GaussianBeamProfile(1e-3, 3e-3)));
 
     // configure the excitation signal
     const auto fs          = 100e6f;

--- a/src/qt5gui/MainWindow.cpp
+++ b/src/qt5gui/MainWindow.cpp
@@ -663,7 +663,7 @@ void MainWindow::onNewExcitation(bcsim::ExcitationSignal new_excitation) {
 
 void MainWindow::onNewBeamProfile(bcsim::IBeamProfile::s_ptr new_beamprofile) {
     if (std::dynamic_pointer_cast<bcsim::GaussianBeamProfile>(new_beamprofile)) {
-        m_sim->set_beam_profile(new_beamprofile);
+        m_sim->set_analytical_profile(new_beamprofile);
     } else if (std::dynamic_pointer_cast<bcsim::LUTBeamProfile>(new_beamprofile)) {
         m_sim->set_lookup_profile(new_beamprofile);
     } else {

--- a/src/qt5gui/MainWindow.cpp
+++ b/src/qt5gui/MainWindow.cpp
@@ -229,7 +229,7 @@ void MainWindow::createMenus() {
     connect(refresh_settings_act, SIGNAL(triggered()), this, SLOT(onLoadIniSettings()));
     fileMenu->addAction(refresh_settings_act);
 
-    auto load_beamprofile_lut_act = new QAction(tr("Load LUT beamprofile [experimental!]"), this);
+    auto load_beamprofile_lut_act = new QAction(tr("Load LUT beamprofile"), this);
     connect(load_beamprofile_lut_act, SIGNAL(triggered()), this, SLOT(onLoadBeamProfileLUT()));
     fileMenu->addAction(load_beamprofile_lut_act);
 

--- a/src/qt5gui/MainWindow.cpp
+++ b/src/qt5gui/MainWindow.cpp
@@ -356,7 +356,7 @@ void MainWindow::onCreateGpuSimulator() {
         // configure Gaussian beam profile
         const auto sigma_lateral     = m_beamprofile_widget->get_lateral_sigma();
         const auto sigma_elevational = m_beamprofile_widget->get_elevational_sigma();
-        m_sim->set_beam_profile(bcsim::IBeamProfile::s_ptr(new bcsim::GaussianBeamProfile(sigma_lateral, sigma_elevational)));
+        m_sim->set_analytical_profile(bcsim::IBeamProfile::s_ptr(new bcsim::GaussianBeamProfile(sigma_lateral, sigma_elevational)));
 
         updateOpenGlVisualization();
     }
@@ -497,7 +497,7 @@ void MainWindow::initializeSimulator(const std::string& type) {
     // For now hardcoded to use analytic Gaussian beam profile
     //auto beam_profile = m_beamprofile_widget->getValue();
     auto beam_profile = bcsim::IBeamProfile::s_ptr(new bcsim::GaussianBeamProfile(0.5e-3f, 1.0e-3f));
-    m_sim->set_beam_profile(beam_profile);
+    m_sim->set_analytical_profile(beam_profile);
 
     qDebug() << "Created simulator";
     // force-emit from all widgets to ensure a fully configured simulator.
@@ -662,7 +662,14 @@ void MainWindow::onNewExcitation(bcsim::ExcitationSignal new_excitation) {
 }
 
 void MainWindow::onNewBeamProfile(bcsim::IBeamProfile::s_ptr new_beamprofile) {
-    m_sim->set_beam_profile(new_beamprofile);
+    if (std::dynamic_pointer_cast<bcsim::GaussianBeamProfile>(new_beamprofile)) {
+        m_sim->set_beam_profile(new_beamprofile);
+    } else if (std::dynamic_pointer_cast<bcsim::LUTBeamProfile>(new_beamprofile)) {
+        m_sim->set_lookup_profile(new_beamprofile);
+    } else {
+        throw std::runtime_error("onNewBeamProfile(): all casts failed");
+    }
+
     qDebug() << "Configured beam profile";
 }
 

--- a/utilities/make_lut.py
+++ b/utilities/make_lut.py
@@ -1,0 +1,51 @@
+import numpy as np
+import argparse
+import h5py
+
+description="""
+    Script for generating a gaussian lookup-table.
+    
+    It should yield similar results as the analytical
+    beam profile.
+"""
+
+if __name__ == '__main__':
+    sigma_lat = 1e-3
+    sigma_ele = 1e-3
+    num_rad_samples = 128
+    num_lat_samples = 64
+    num_ele_samples = 63
+    r_min = 0.0; r_max = 0.12
+    l_min = -3e-3; l_max = 3e-3
+    e_min = -3e-3; e_max = 3e-3
+    
+    h5_file = 'gaussian_lut.h5'
+    
+    r_mesh, l_mesh, e_mesh = np.meshgrid(np.linspace(r_min, r_max, num_rad_samples),
+                                         np.linspace(l_min, l_max, num_lat_samples),
+                                         np.linspace(e_min, e_max, num_ele_samples),
+                                         indexing='ij')
+    
+    beam_profile = np.exp( -(l_mesh**2/sigma_lat**2 + e_mesh**2/sigma_ele**2) )
+
+    # probably a nicer way to do this...
+    for rad_idx, r_norm in enumerate(np.linspace(0.0, 1.0, num_rad_samples)):
+        w = 1.0/(2*r_norm+0.1)
+        print 'Radial index: %d: w=%f' % (rad_idx, w)
+        beam_profile[rad_idx, :, :] *= w
+        
+    print beam_profile[0,:,:]
+    print beam_profile[-1,:,:]
+    
+    with h5py.File(h5_file, 'w') as f:
+        f["beam_profile"] = np.array(beam_profile, dtype='float32')
+        f["rad_extent"]   = np.array([r_min, r_max], dtype='float32')
+        f["lat_extent"]   = np.array([l_min, l_max], dtype='float32')
+        f["ele_extent"]   = np.array([e_min, e_max], dtype='float32')
+        
+    if True:
+        import matplotlib.pyplot as plt
+        rad_idx = num_rad_samples/2
+        plt.imshow(beam_profile[rad_idx,:,:])
+        plt.show()
+    

--- a/utilities/make_lut.py
+++ b/utilities/make_lut.py
@@ -12,8 +12,8 @@ description="""
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("h5_file", help="Output beam profile")
-    parser.add_argument("--rad_min", type=float, default=-2e-2)
-    parser.add_argument("--rad_max", type=float, default=2e-2)
+    parser.add_argument("--rad_min", type=float, default=0.0)
+    parser.add_argument("--rad_max", type=float, default=0.15)
     parser.add_argument("--ele_min", type=float, default=-2e-2)
     parser.add_argument("--ele_max", type=float, default=2e-2)
     parser.add_argument("--lat_min", type=float, default=-2e-2)

--- a/utilities/make_lut.py
+++ b/utilities/make_lut.py
@@ -21,8 +21,8 @@ if __name__ == "__main__":
     parser.add_argument("--num_samples_rad", type=int, default=128)
     parser.add_argument("--num_samples_lat", type=int, default=32)
     parser.add_argument("--num_samples_ele", type=int, default=32)
-    parser.add_argument("--r_min", help="Radius at start depth", type=float, default=5e-3)
-    parser.add_argument("--r_max", help="Radius at end depth", type=float, default=13e-3)
+    parser.add_argument("--r_min", help="Radius at start depth", type=float, default=1e-3)
+    parser.add_argument("--r_max", help="Radius at end depth", type=float, default=8e-3)
     args = parser.parse_args()
     
     data_dims = (args.num_samples_rad, args.num_samples_lat, args.num_samples_ele)

--- a/utilities/visualize_beam_profile.py
+++ b/utilities/visualize_beam_profile.py
@@ -1,0 +1,42 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import h5py
+import argparse
+
+description="""
+    Plot simulated beam profile.
+"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("h5_file")
+    args = parser.parse_args()
+    
+    with h5py.File(args.h5_file, "r") as f:
+        beam_profile = f["beam_profile"].value
+        ele_extent = f["ele_extent"].value
+        lat_extent = f["lat_extent"].value
+        rad_extent = f["rad_extent"].value
+    
+    print "Radial extent: %s" % str(rad_extent)
+    print "Lateral extent: %s" % str(lat_extent)
+    print "Elevational extent: %s" % str(ele_extent)        
+    
+    print "Min sample value: %e" % np.min(beam_profile.flatten())
+    print "Max sample value: %e" % np.max(beam_profile.flatten())
+    
+    rad_dim = 0
+    num_rad_samples = beam_profile.shape[rad_dim]
+    
+    plt.figure()
+    plt.ion()
+    plt.show()
+    img_extent = [ele_extent[0], ele_extent[1], lat_extent[0], lat_extent[1]] # riktig?
+    for r_idx in range(num_rad_samples):
+        plt.clf()
+        plt.imshow(beam_profile[r_idx,:,:], extent=img_extent, cmap="Greys", aspect="auto", interpolation="nearest")
+        plt.draw()
+        plt.title("Radial index %d of %d" % (r_idx+1, num_rad_samples))
+        plt.colorbar()
+        raw_input("Press enter")
+    


### PR DESCRIPTION
Adds support for lookup-table based beam profiles for all GPU algorithms also.
The lookup table code on CPU has been improved with tri-linear interpolation instead of nearest voxel. This closes #25
