### PR TITLE
Constant spline amplitudes

### DIFF
--- a/create_all_phantoms.py
+++ b/create_all_phantoms.py
@@ -249,5 +249,5 @@ if __name__ == '__main__':
     create_2d_cyst_phantom()
     create_simple_phantom()
     print 'NOTE: This is the last script and may take a while to finish...'
-    #create_artery_phantom()
+    create_artery_phantom()
     

--- a/phantom_scripts/contracting_cylinder_spline.py
+++ b/phantom_scripts/contracting_cylinder_spline.py
@@ -29,26 +29,25 @@ def create_phantom(args):
     num_scatterers = len(xs)
     
     # Create random amplitudes
-    _as = np.random.uniform(low=0.0, high=1.0, size=(num_scatterers,))  
+    amplitudes = np.random.uniform(low=0.0, high=1.0, size=(num_scatterers,))  
     
     # Create knot vector
     knots = bsplines.uniform_regular_knot_vector(args.num_control_points, args.spline_degree,
                                                  t0=start_time, t1=end_time)
     knot_avgs = bsplines.control_points(args.spline_degree, knots)
     
-    nodes = np.empty((num_scatterers, args.num_control_points, 4), dtype='float32')
+    control_points = np.empty((num_scatterers, args.num_control_points, 3), dtype='float32')
 
     for c_i, t_star in enumerate(knot_avgs):
         alpha = scale_fn(t_star)
-        nodes[:, c_i, 0] = xs/np.sqrt(alpha)
-        nodes[:, c_i, 1] = ys/np.sqrt(alpha)
-        nodes[:, c_i, 2] = zs*alpha
-        nodes[:, c_i, 3] = _as
-    
+        control_points[:, c_i, 0] = xs/np.sqrt(alpha)
+        control_points[:, c_i, 1] = ys/np.sqrt(alpha)
+        control_points[:, c_i, 2] = zs*alpha
 
     with h5py.File(args.h5_out, 'w') as f:
         f["spline_degree"] = args.spline_degree
-        f["nodes"] = nodes
+        f["control_points"] = control_points
+        f["amplitudes"] = np.array(amplitudes, dtype="float32")
         f["knot_vector"] = np.array(knots, dtype='float32')    
     print 'Spline scatterer dataset written to %s' % args.h5_out
     

--- a/phantom_scripts/harmonic_box.py
+++ b/phantom_scripts/harmonic_box.py
@@ -19,22 +19,23 @@ def create_phantom(args):
     
     knot_avgs = bsplines.control_points(args.spline_degree, knot_vector)
     
-    nodes = np.empty( (args.num_scatterers, args.num_control_points, 4), dtype='float32')        
+    control_points = np.empty( (args.num_scatterers, args.num_control_points, 3), dtype='float32')        
+    amplitudes = np.random.uniform(low=0.0, high=1.0, size=(args.num_scatterers,))
     for scatterer_i in range(args.num_scatterers):
         print 'Scatterer %d of %d' % (scatterer_i, args.num_scatterers)
         # generate random start point
         x0 = random.uniform(args.x_min, args.x_max)
         y0 = random.uniform(args.y_min, args.y_max)
         z0 = args.z0 + random.uniform(-0.5, 0.5)*args.thickness
-        scatterer_amplitude=random.uniform(0.0, 1.0)       
         for control_pt_i, t_star in enumerate(knot_avgs):
             x = x0
             y = y0
             z = z0 + args.ampl*np.cos(2*np.pi*args.freq*t_star)
-            nodes[scatterer_i, control_pt_i, :] = [x, y, z, scatterer_amplitude]                     
+            control_points[scatterer_i, control_pt_i, :] = [x, y, z]                     
     
     with h5py.File(args.h5_file, 'w') as f:
-        f["nodes"] = nodes
+        f["control_points"] = control_points
+        f["amplitudes"] = np.array(amplitudes, dtype="float32")
         f["spline_degree"] = args.spline_degree
         f["file_format_version"] = "1"
         f["knot_vector"] = knot_vector

--- a/phantom_scripts/lv_spline_model.py
+++ b/phantom_scripts/lv_spline_model.py
@@ -70,24 +70,24 @@ def create_phantom(args):
     knot_vector = np.array(knot_vector, dtype='float32')
     knot_avgs = bsplines.control_points(args.spline_degree, knot_vector)
 
-    nodes = np.zeros( (num_scatterers, args.num_cs, 4), dtype='float32')
+    control_points = np.zeros( (num_scatterers, args.num_cs, 3), dtype='float32')
     for cs_i, t_star in enumerate(knot_avgs):
         print 'Computing control points for knot average %d of %d' % (cs_i+1, args.num_cs)
 
         s = scale_fn(t_star)
 
         # Compute control point position. Amplitude is unchanged.
-        nodes[:,cs_i,0] = s*np.array(xs)
-        nodes[:,cs_i,1] = s*np.array(ys)
-        nodes[:,cs_i,2] = s*np.array(zs)
-        nodes[:,cs_i,3] = _as 
+        control_points[:,cs_i,0] = s*np.array(xs)
+        control_points[:,cs_i,1] = s*np.array(ys)
+        control_points[:,cs_i,2] = s*np.array(zs)
 
     
     # Write results to disk
     with h5py.File(args.h5_file) as f:
         f['spline_degree'] = args.spline_degree
         f['knot_vector'] = knot_vector
-        f['nodes'] = nodes
+        f['control_points'] = control_points
+        f['amplitudes'] = np.array(_as, dtype="float32")
     
     print 'Spline scatterer dataset written to %s' % args.h5_file
 

--- a/phantom_scripts/rotating_cube.py
+++ b/phantom_scripts/rotating_cube.py
@@ -21,7 +21,7 @@ def create_phantom(args):
     scatterers[1, :] = ys
     scatterers[2, :] = zs
     
-    nodes = np.empty( (args.num_scatterers, args.num_cs, 4), dtype='float32')
+    control_points = np.empty( (args.num_scatterers, args.num_cs, 3), dtype='float32')
     
     knots = bsplines.uniform_regular_knot_vector(args.num_cs, args.spline_degree, t0=args.t0, t1=args.t1)
     knot_avgs = bsplines.control_points(args.spline_degree, knots)
@@ -36,12 +36,12 @@ def create_phantom(args):
         
         temp = np.dot(rot_mat, scatterers).transpose()
         temp[:, 2] += args.z0
-        nodes[:, control_point_i, 0:3] = temp
-        nodes[:, control_point_i, 3] = as_
+        control_points[:, control_point_i, 0:3] = temp
            
     with h5py.File(args.h5_file, 'w') as f:
         f["spline_degree"] = args.spline_degree
-        f["nodes"] = nodes
+        f["control_points"] = control_points
+        f["amplitudes"] = np.array(as_, dtype="float32")
         f["knot_vector"] = knots
 
 if __name__ == '__main__':

--- a/phantom_scripts/rotating_plaque.py
+++ b/phantom_scripts/rotating_plaque.py
@@ -37,22 +37,25 @@ def create_phantom(args):
     knot_vector = np.array(knot_vector, dtype='float32')
     knot_avgs = bsplines.control_points(args.spline_degree, knot_vector)
 
-    nodes = np.zeros( (num_scatterers, args.num_cs, 4), dtype='float32')
+    control_points = np.zeros( (num_scatterers, args.num_cs, 3), dtype='float32')
+    amplitudes = np.zeros( (num_scatterers,), dtype="float32")
     
     for i in range(args.num_cs):
         theta = i*np.pi*2/args.num_cs
-        nodes[:num_tissue_scatterers,i,0] = xs
-        nodes[:num_tissue_scatterers,i,1] = ys
-        nodes[:num_tissue_scatterers,i,2] = zs
-        nodes[:num_tissue_scatterers,i,3] = ampls
+        control_points[:num_tissue_scatterers,i,0] = xs
+        control_points[:num_tissue_scatterers,i,1] = ys
+        control_points[:num_tissue_scatterers,i,2] = zs
 
-        nodes[num_tissue_scatterers:,i,0] = plaque_xs + args.radius*np.sin(theta)
-        nodes[num_tissue_scatterers:,i,1] = plaque_ys
-        nodes[num_tissue_scatterers:,i,2] = plaque_zs + args.z0 + args.radius*np.cos(theta)
-        nodes[num_tissue_scatterers:,i,3] = plaque_ampls
+        control_points[num_tissue_scatterers:,i,0] = plaque_xs + args.radius*np.sin(theta)
+        control_points[num_tissue_scatterers:,i,1] = plaque_ys
+        control_points[num_tissue_scatterers:,i,2] = plaque_zs + args.z0 + args.radius*np.cos(theta)
+
+        amplitudes[num_tissue_scatterers:] = plaque_ampls
+        amplitudes[:num_tissue_scatterers] = ampls
     
     with h5py.File(args.h5_file, 'w') as f:
-        f["nodes"] = nodes
+        f["control_points"] = control_points
+        f["amplitudes"] = amplitudes
         f["spline_degree"] = args.spline_degree
         f["knot_vector"] = knot_vector
     

--- a/phantom_scripts/spline_noise.py
+++ b/phantom_scripts/spline_noise.py
@@ -8,13 +8,14 @@ description = """\
 """
 
 def create_phantom(args):
-    nodes = np.empty((args.num_scatterers, args.num_cs, 4), dtype='float32')
-    nodes[:,:,0] = np.random.uniform(size=(args.num_scatterers, args.num_cs), low=args.x_min, high=args.x_max)
-    nodes[:,:,1] = np.random.uniform(size=(args.num_scatterers, args.num_cs), low=args.y_min, high=args.y_max)
-    nodes[:,:,2] = np.random.uniform(size=(args.num_scatterers, args.num_cs), low=args.z_min, high=args.z_max)
-    nodes[:,:,3] = np.random.uniform(size=(args.num_scatterers, args.num_cs), low=0.0, high=1.0)
+    control_points = np.empty((args.num_scatterers, args.num_cs, 3), dtype='float32')
+    control_points[:,:,0] = np.random.uniform(size=(args.num_scatterers, args.num_cs), low=args.x_min, high=args.x_max)
+    control_points[:,:,1] = np.random.uniform(size=(args.num_scatterers, args.num_cs), low=args.y_min, high=args.y_max)
+    control_points[:,:,2] = np.random.uniform(size=(args.num_scatterers, args.num_cs), low=args.z_min, high=args.z_max)
+    amplitudes = np.random.uniform(size=(args.num_scatterers,), low=0.0, high=1.0)
     with h5py.File(args.h5_file, 'w') as f:
-        f["nodes"] = nodes
+        f["control_points"] = control_points
+        f["amplitudes"] = np.array(amplitudes, dtype="float32")
         f["spline_degree"] = args.spline_degree
         f["knot_vector"] = np.array(bsplines.uniform_regular_knot_vector(args.num_cs, args.spline_degree, t0=0.0, t1=1.001), dtype='float32')
     print 'Dataset written to %s' % args.h5_file

--- a/python/demo_pw_doppler.py
+++ b/python/demo_pw_doppler.py
@@ -58,12 +58,13 @@ if __name__ == "__main__":
     
     # Set spline scatterers
     with h5py.File(args.scatterer_file, "r") as f:
-        nodes         = np.array(f["nodes"].value, dtype="float32")
-        knot_vector   = np.array(f["knot_vector"].value, dtype="float32")
-        spline_degree = int(f["spline_degree"].value)
+        control_points = np.array(f["control_points"].value, dtype="float32")
+        amplitudes     = np.array(f["amplitudes"].value, dtype="float32")
+        knot_vector    = np.array(f["knot_vector"].value, dtype="float32")
+        spline_degree  = int(f["spline_degree"].value)
         
-    sim.set_spline_scatterers(spline_degree, knot_vector, nodes)
-    print "Number of scatterers: %d" % nodes.shape[0]
+    sim.set_spline_scatterers(spline_degree, knot_vector, control_points, amplitudes)
+    print "Number of scatterers: %d" % control_points.shape[0]
     
     # Define excitation signal
     t_vector = np.arange(-16/args.fc, 16/args.fc, 1.0/args.fs)

--- a/src/BCSimConfig.hpp
+++ b/src/BCSimConfig.hpp
@@ -113,9 +113,6 @@ struct SplineScatterers : public Scatterers {
     // all point scatterers.
     int                         spline_degree;
     std::vector<bc_float>       knot_vector;
-    // TODO: Consider adding number of control points since common
-    // for all. Currently an element in 'nodes' must be inspected
-    // to determine it, which is inconvenient.
     
     // For each point scatterer: a list of spline control points.
     std::vector<std::vector<PointScatterer> > nodes;

--- a/src/BCSimConfig.hpp
+++ b/src/BCSimConfig.hpp
@@ -108,6 +108,15 @@ struct SplineScatterers : public Scatterers {
     virtual int num_scatterers() const {
         return static_cast<int>(nodes.size());
     }
+
+    // Returns the number of control points for each spline
+    // scatterer (same for all scatterers).
+    size_t get_num_control_points() const {
+        if (nodes.size() == 0) {
+            throw std::runtime_error("No scatterers in dataset");
+        }
+        return nodes[0].size();
+    }
     
     // Spline degree and knot vector are common for
     // all point scatterers.

--- a/src/BCSimConfig.hpp
+++ b/src/BCSimConfig.hpp
@@ -106,16 +106,17 @@ struct SplineScatterers : public Scatterers {
     typedef std::shared_ptr<SplineScatterers> s_ptr;
 
     virtual int num_scatterers() const {
-        return static_cast<int>(nodes.size());
+        // assert(control_points.size() == amplitudes.size());
+        return static_cast<int>(control_points.size());
     }
 
     // Returns the number of control points for each spline
     // scatterer (same for all scatterers).
     size_t get_num_control_points() const {
-        if (nodes.size() == 0) {
+        if (num_scatterers() == 0) {
             throw std::runtime_error("No scatterers in dataset");
         }
-        return nodes[0].size();
+        return control_points[0].size();
     }
     
     // Spline degree and knot vector are common for
@@ -123,8 +124,10 @@ struct SplineScatterers : public Scatterers {
     int                         spline_degree;
     std::vector<bc_float>       knot_vector;
     
-    // For each point scatterer: a list of spline control points.
-    std::vector<std::vector<PointScatterer> > nodes;
+    // For each scatterer: list of control points in space and a scalar amplitude
+    // Indexed by scatterer no.
+    std::vector<std::vector<vector3>> control_points;
+    std::vector<bc_float>             amplitudes;
 };
 
 

--- a/src/BCSimConvenience.cpp
+++ b/src/BCSimConvenience.cpp
@@ -103,9 +103,9 @@ Scatterers::s_ptr render_fixed_scatterers(SplineScatterers::s_ptr spline_scatter
     for (size_t spline_no = 0; spline_no < num_scatterers; spline_no++) {
         PointScatterer scatterer;
         scatterer.pos       = vector3(0.0f, 0.0f, 0.0f);
-        scatterer.amplitude = spline_scatterers->nodes[spline_no][0].amplitude; // TEMPORARY HACK: Using amplitude of first scatterer
+        scatterer.amplitude = spline_scatterers->amplitudes[spline_no];
         for (size_t i = 0; i < num_cs; i++) {
-            scatterer.pos += spline_scatterers->nodes[spline_no][i].pos*basis_fn[i];
+            scatterer.pos += spline_scatterers->control_points[spline_no][i]*basis_fn[i];
         }
         res->scatterers[spline_no] = scatterer;
     }

--- a/src/BCSimConvenience.cpp
+++ b/src/BCSimConvenience.cpp
@@ -92,7 +92,7 @@ Scatterers::s_ptr render_fixed_scatterers(SplineScatterers::s_ptr spline_scatter
     
         
     // precompute basis functions
-    const auto num_cs = spline_scatterers->nodes[0].size();
+    const auto num_cs = spline_scatterers->get_num_control_points();
     std::vector<float> basis_fn(num_cs);
     for (size_t i = 0; i < num_cs; i++) {
         basis_fn[i] = bspline_storve::bsplineBasis(i, spline_scatterers->spline_degree, timestamp, spline_scatterers->knot_vector);

--- a/src/BCSimConvenience.cpp
+++ b/src/BCSimConvenience.cpp
@@ -103,10 +103,9 @@ Scatterers::s_ptr render_fixed_scatterers(SplineScatterers::s_ptr spline_scatter
     for (size_t spline_no = 0; spline_no < num_scatterers; spline_no++) {
         PointScatterer scatterer;
         scatterer.pos       = vector3(0.0f, 0.0f, 0.0f);
-        scatterer.amplitude = 0.0f;
+        scatterer.amplitude = spline_scatterers->nodes[spline_no][0].amplitude; // TEMPORARY HACK: Using amplitude of first scatterer
         for (size_t i = 0; i < num_cs; i++) {
-            scatterer.pos       += spline_scatterers->nodes[spline_no][i].pos*basis_fn[i];
-            scatterer.amplitude += spline_scatterers->nodes[spline_no][i].amplitude*basis_fn[i];
+            scatterer.pos += spline_scatterers->nodes[spline_no][i].pos*basis_fn[i];
         }
         res->scatterers[spline_no] = scatterer;
     }

--- a/src/HDFConvenience.cpp
+++ b/src/HDFConvenience.cpp
@@ -168,16 +168,15 @@ Scatterers::s_ptr loadSplineScatterersFromHdf(const std::string& h5_file) {
         if (num_comp != 4) {
             throw std::runtime_error("SplineScatterer illegal number of components (should be 4)");
         }
-        res->nodes.resize(num_scatterers);
+        res->control_points.resize(num_scatterers);
+        res->amplitudes.resize(num_scatterers);
         for (size_t scatterer_no = 0; scatterer_no < num_scatterers; scatterer_no++) {
-            std::vector<PointScatterer> control_points;
+            res->amplitudes[scatterer_no] = nodes[scatterer_no][0][3]; // TEMPORARY HACK: using amplitude from first scatterer control points
+
             for (size_t cs_no = 0; cs_no < num_cs; cs_no++) {
-                PointScatterer scatterer;
-                scatterer.pos = vector3(nodes[scatterer_no][cs_no][0], nodes[scatterer_no][cs_no][1], nodes[scatterer_no][cs_no][2]);
-                scatterer.amplitude = nodes[scatterer_no][cs_no][3];
-                control_points.push_back(scatterer);
+                const vector3 pt(nodes[scatterer_no][cs_no][0], nodes[scatterer_no][cs_no][1], nodes[scatterer_no][cs_no][2]);
+                res->control_points[scatterer_no].push_back(pt);
             }
-            res->nodes[scatterer_no] = control_points;
         }
     } catch (...) {
         throw std::runtime_error("Failed to configure spline scatterer dataset");

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -92,7 +92,8 @@ public:
 
     void set_spline_scatterers(int spline_degree,
                                numpy_boost<float, 1> knot_vector,
-                               numpy_boost<float, 3> nodes) {
+                               numpy_boost<float, 3> control_points,
+                               numpy_boost<float, 1> amplitudes) {
 
         auto new_scatterers = SplineScatterers::s_ptr(new SplineScatterers);
         
@@ -109,12 +110,12 @@ public:
         }
         
         // Get size for all three dimensions of nodes array
-        auto node_dims = get_dimensions(nodes);
-        if (node_dims.size() != 3) {
-            throw std::runtime_error(std::string(__FUNCTION__) + " : invalid nodes rank");
+        auto control_points_dims = get_dimensions(control_points);
+        if (control_points_dims.size() != 3) {
+            throw std::runtime_error(std::string(__FUNCTION__) + " : invalid control_points rank");
         }
-        int num_scatterers = node_dims[0];
-        int num_control_points = node_dims[1];
+        int num_scatterers = control_points_dims[0];
+        int num_control_points = control_points_dims[1];
         
         // Sanity check
         if (num_knots != (num_control_points + spline_degree + 1)) {
@@ -124,23 +125,27 @@ public:
         std::cout << "Number of scatterers: " << num_scatterers << std::endl;
         std::cout << "Number of control points for each scatterer: " << num_control_points << std::endl;
         
-        if (node_dims[2] != 4) {
-            throw std::runtime_error(std::string(__FUNCTION__) + " : size of dimension 3 must be four (x,y,z,ampl)");
+        if (control_points_dims[2] != 3) {
+            throw std::runtime_error(std::string(__FUNCTION__) + " : size of dimension 3 must be three (x,y,z)");
+        }
+
+        const auto amplitudes_size = get_dimensions(amplitudes);
+        if (amplitudes_size[0] != num_scatterers) {
+            throw std::runtime_error("Mismatch between control_points and amplitudes");
         }
                 
-        
         new_scatterers->control_points.resize(num_scatterers);
         new_scatterers->amplitudes.resize(num_scatterers);
 
         for (int scatterer_i = 0; scatterer_i < num_scatterers; scatterer_i++) {
-            new_scatterers->amplitudes[scatterer_i] = nodes[scatterer_i][0][3];     // TEMPORARY HACK: Using amplitude from first control point
+            new_scatterers->amplitudes[scatterer_i] = amplitudes[scatterer_i];
 
             new_scatterers->control_points[scatterer_i].resize(num_control_points);
             for (int control_point_i = 0; control_point_i < num_control_points; control_point_i++) {
                
-                const vector3 pos(nodes[scatterer_i][control_point_i][0],
-                                  nodes[scatterer_i][control_point_i][1],
-                                  nodes[scatterer_i][control_point_i][2]);
+                const vector3 pos(control_points[scatterer_i][control_point_i][0],
+                                  control_points[scatterer_i][control_point_i][1],
+                                  control_points[scatterer_i][control_point_i][2]);
                 
                 new_scatterers->control_points[scatterer_i][control_point_i] = pos;
             }

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -129,18 +129,20 @@ public:
         }
                 
         
-        new_scatterers->nodes.resize(num_scatterers);
+        new_scatterers->control_points.resize(num_scatterers);
+        new_scatterers->amplitudes.resize(num_scatterers);
+
         for (int scatterer_i = 0; scatterer_i < num_scatterers; scatterer_i++) {
-            new_scatterers->nodes[scatterer_i].resize(num_control_points);
+            new_scatterers->amplitudes[scatterer_i] = nodes[scatterer_i][0][3];     // TEMPORARY HACK: Using amplitude from first control point
+
+            new_scatterers->control_points[scatterer_i].resize(num_control_points);
             for (int control_point_i = 0; control_point_i < num_control_points; control_point_i++) {
-                PointScatterer scatterer;
+               
+                const vector3 pos(nodes[scatterer_i][control_point_i][0],
+                                  nodes[scatterer_i][control_point_i][1],
+                                  nodes[scatterer_i][control_point_i][2]);
                 
-                scatterer.pos = vector3(nodes[scatterer_i][control_point_i][0],
-                                        nodes[scatterer_i][control_point_i][1],
-                                        nodes[scatterer_i][control_point_i][2]);
-                
-                scatterer.amplitude = nodes[scatterer_i][control_point_i][3];
-                new_scatterers->nodes[scatterer_i][control_point_i] = scatterer;
+                new_scatterers->control_points[scatterer_i][control_point_i] = pos;
             }
         }
 

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -72,9 +72,10 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
         // Compute position of current scatterer by evaluating spline in current timestep        
         PointScatterer scatterer;
         scatterer.pos = vector3(0.0f, 0.0f, 0.0f); // TODO: not neccessary to set to zero since constructor does that?
-        scatterer.amplitude = m_scatterers->nodes[scatterer_no][0].amplitude; // TEMPORARY HACK: using amplitude of first control point.
+        scatterer.amplitude = m_scatterers->amplitudes[scatterer_no]; // TEMPORARY HACK: using amplitude of first control point.
+
         for (int i = 0; i < num_control_points; i++) {
-            scatterer.pos       += m_scatterers->nodes[scatterer_no][i].pos*basis_functions[i];
+            scatterer.pos       += m_scatterers->control_points[scatterer_no][i]*basis_functions[i];
         }
         
         // Map the global cartesian scatterer position into the beam's local

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -56,9 +56,8 @@ void CpuSplineAlgorithm::set_scatterers(Scatterers::s_ptr new_scatterers) {
 
 void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<float>* time_proj_signal, size_t num_time_samples) {
 
-    const int num_scatterers = m_scatterers->nodes.size();
-    // TODO: Improve. Use that all splines have same number of control points
-    const int num_control_points = m_scatterers->nodes[0].size();
+    const int num_scatterers = m_scatterers->num_scatterers();
+    const int num_control_points = m_scatterers->get_num_control_points();
     std::vector<bc_float> basis_functions(num_control_points);
     
     // Precompute all B-spline basis function for current timestep

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -69,18 +69,16 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
         basis_functions[i] = b;
     }
     for (int scatterer_no = 0; scatterer_no < num_scatterers; scatterer_no++) {
-        // Compute position of current scatterer by evaluating spline in current timestep        
-        PointScatterer scatterer;
-        scatterer.pos = vector3(0.0f, 0.0f, 0.0f); // TODO: not neccessary to set to zero since constructor does that?
-        scatterer.amplitude = m_scatterers->amplitudes[scatterer_no]; // TEMPORARY HACK: using amplitude of first control point.
 
+        // Compute position of current scatterer by evaluating spline in current timestep        
+        vector3 scatterer_pos(0.0f, 0.0f, 0.0f);
         for (int i = 0; i < num_control_points; i++) {
-            scatterer.pos       += m_scatterers->control_points[scatterer_no][i]*basis_functions[i];
+            scatterer_pos += m_scatterers->control_points[scatterer_no][i]*basis_functions[i];
         }
         
         // Map the global cartesian scatterer position into the beam's local
         // coordinate system.
-        vector3 temp = scatterer.pos - line.get_origin();
+        vector3 temp = scatterer_pos - line.get_origin();
         bc_float r = temp.dot(line.get_direction());       // radial component
         bc_float l = temp.dot(line.get_lateral_dir());     // lateral component
         bc_float e = temp.dot(line.get_elevational_dir()); // elevational component
@@ -100,7 +98,7 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
         const bc_float sampling_time_step = 1.0/m_excitation.sampling_frequency;
         int closest_index = (int) std::floor(r*2.0/(m_param_sound_speed*sampling_time_step)+0.5f);
         
-        bc_float scaled_ampl = m_beam_profile->sampleProfile(r,l,e)*scatterer.amplitude;
+        bc_float scaled_ampl = m_beam_profile->sampleProfile(r,l,e)*m_scatterers->amplitudes[scatterer_no];
         
         // Avoid out of bound seg.fault
         if (closest_index < 0 || closest_index >= num_time_samples) {

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -73,10 +73,9 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
         // Compute position of current scatterer by evaluating spline in current timestep        
         PointScatterer scatterer;
         scatterer.pos = vector3(0.0f, 0.0f, 0.0f); // TODO: not neccessary to set to zero since constructor does that?
-        scatterer.amplitude = 0.0f;
+        scatterer.amplitude = m_scatterers->nodes[scatterer_no][0].amplitude; // TEMPORARY HACK: using amplitude of first control point.
         for (int i = 0; i < num_control_points; i++) {
             scatterer.pos       += m_scatterers->nodes[scatterer_no][i].pos*basis_functions[i];
-            scatterer.amplitude += m_scatterers->nodes[scatterer_no][i].amplitude*basis_functions[i];
         }
         
         // Map the global cartesian scatterer position into the beam's local

--- a/src/algorithm/GpuSplineAlgorithm1.cu
+++ b/src/algorithm/GpuSplineAlgorithm1.cu
@@ -61,12 +61,11 @@ __global__ void RenderSplineKernel(const float* control_xs,
     float rendered_x = 0.0f;
     float rendered_y = 0.0f;
     float rendered_z = 0.0f;
-    float rendered_a = 0.0f;
+    float rendered_a = control_as[NUM_SPLINES*0 + idx]; // TEMPORARY HACK: using amplitude from first node
     for (int i = 0; i < NUM_CS; i++) {
         rendered_x += control_xs[NUM_SPLINES*i + idx]*eval_basis[i];
         rendered_y += control_ys[NUM_SPLINES*i + idx]*eval_basis[i];
         rendered_z += control_zs[NUM_SPLINES*i + idx]*eval_basis[i];
-        rendered_a += control_as[NUM_SPLINES*i + idx]*eval_basis[i];
     }
 
     // write result to memory

--- a/src/algorithm/GpuSplineAlgorithm1.cu
+++ b/src/algorithm/GpuSplineAlgorithm1.cu
@@ -120,10 +120,10 @@ void GpuSplineAlgorithm1::set_scatterers(Scatterers::s_ptr new_scatterers) {
     for (size_t spline_no = 0; spline_no < m_num_splines; spline_no++) {
         for (size_t i = 0; i < m_num_cs; i++) {
             const size_t offset = spline_no + i*m_num_splines;
-            host_control_xs[offset] = scatterers->nodes[spline_no][i].pos.x;
-            host_control_ys[offset] = scatterers->nodes[spline_no][i].pos.y;
-            host_control_zs[offset] = scatterers->nodes[spline_no][i].pos.z;
-            host_control_as[offset] = scatterers->nodes[spline_no][i].amplitude;
+            host_control_xs[offset] = scatterers->control_points[spline_no][i].x;
+            host_control_ys[offset] = scatterers->control_points[spline_no][i].y;
+            host_control_zs[offset] = scatterers->control_points[spline_no][i].z;
+            host_control_as[offset] = scatterers->amplitudes[spline_no]; // TODO: UPDATE
         }
     }
     

--- a/src/algorithm/GpuSplineAlgorithm1.cu
+++ b/src/algorithm/GpuSplineAlgorithm1.cu
@@ -93,7 +93,7 @@ void GpuSplineAlgorithm1::set_scatterers(Scatterers::s_ptr new_scatterers) {
         throw std::runtime_error("No scatterers");
     }
     m_spline_degree = scatterers->spline_degree;
-    m_num_cs = scatterers->nodes[0].size();
+    m_num_cs = scatterers->get_num_control_points();
 
     if (m_num_cs > MAX_CS) {
         throw std::runtime_error("Too many control points in spline");

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -353,10 +353,10 @@ void GpuSplineAlgorithm2::copy_scatterers_to_device(SplineScatterers::s_ptr scat
     for (size_t spline_no = 0; spline_no < m_num_splines; spline_no++) {
         for (size_t i = 0; i < m_num_cs; i++) {
             const size_t offset = spline_no + i*m_num_splines;
-            host_control_xs[offset] = scatterers->nodes[spline_no][i].pos.x;
-            host_control_ys[offset] = scatterers->nodes[spline_no][i].pos.y;
-            host_control_zs[offset] = scatterers->nodes[spline_no][i].pos.z;
-            host_control_as[offset] = scatterers->nodes[spline_no][i].amplitude;
+            host_control_xs[offset] = scatterers->control_points[spline_no][i].x;
+            host_control_ys[offset] = scatterers->control_points[spline_no][i].y;
+            host_control_zs[offset] = scatterers->control_points[spline_no][i].z;
+            host_control_as[offset] = scatterers->amplitudes[spline_no];    // TODO: UPDATE
         }
     }
     

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -76,13 +76,12 @@ __global__ void SplineAlgKernel(float* control_xs,
     float rendered_x = 0.0f;
     float rendered_y = 0.0f;
     float rendered_z = 0.0f;
-    float rendered_a = 0.0f;
+    float rendered_a = control_as[NUM_SPLINES*0 + global_idx];  // TEMPORARY HACK: Using first node's amplitude
     for (int i = 0; i < NUM_CS; i++) {
         size_t eval_basis_i = i + eval_basis_offset_elements;
         rendered_x += control_xs[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
         rendered_y += control_ys[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
         rendered_z += control_zs[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
-        rendered_a += control_as[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
     }
 
     // step 2: compute projections
@@ -162,13 +161,12 @@ __global__ void SplineAlgKernel_LUT(float* control_xs,
     float rendered_x = 0.0f;
     float rendered_y = 0.0f;
     float rendered_z = 0.0f;
-    float rendered_a = 0.0f;
+    float rendered_a = control_as[NUM_SPLINES*0 + global_idx]; // TEMPORARY HACK: Using first node's amplitude
     for (int i = 0; i < NUM_CS; i++) {
         size_t eval_basis_i = i + eval_basis_offset_elements;
         rendered_x += control_xs[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
         rendered_y += control_ys[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
         rendered_z += control_zs[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
-        rendered_a += control_as[NUM_SPLINES*i + global_idx]*eval_basis[eval_basis_i];
     }
 
     // step 2: compute projections

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -326,7 +326,7 @@ void GpuSplineAlgorithm2::copy_scatterers_to_device(SplineScatterers::s_ptr scat
         throw std::runtime_error("No scatterers");
     }
     m_spline_degree = scatterers->spline_degree;
-    m_num_cs = scatterers->nodes[0].size();
+    m_num_cs = scatterers->get_num_control_points();
 
     if (m_num_cs > MAX_CS) {
         throw std::runtime_error("Too many control points in spline");

--- a/src/algorithm/GpuSplineAlgorithm2.cuh
+++ b/src/algorithm/GpuSplineAlgorithm2.cuh
@@ -57,10 +57,12 @@ protected:
     
 protected:
     
-    // device memory for spline scatterers control points and amplitudes
+    // device memory for control points for all spline scatterers.
     DeviceBufferRAII<float>::u_ptr      m_device_control_xs;
     DeviceBufferRAII<float>::u_ptr      m_device_control_ys;
     DeviceBufferRAII<float>::u_ptr      m_device_control_zs;
+
+    // device memory for all scatterer amplitudes - one for each scatterer spline.
     DeviceBufferRAII<float>::u_ptr      m_device_control_as;
     
     // The knot vector common to all splines.

--- a/src/examples/gpu_example2.cpp
+++ b/src/examples/gpu_example2.cpp
@@ -149,16 +149,12 @@ void example(int argc, char** argv) {
     std::uniform_real_distribution<float> y_dist(-0.01f, 0.01f);
     std::uniform_real_distribution<float> z_dist(0.04f, 0.10f);
     std::uniform_real_distribution<float> a_dist(-1.0f, 1.0f);
-    spline_scatterers->nodes.clear();
+    spline_scatterers->control_points.clear();
     for (size_t scatterer_no = 0; scatterer_no < num_scatterers; scatterer_no++) {
-        std::vector<bcsim::PointScatterer> control_points;
+        spline_scatterers->amplitudes.push_back( a_dist(gen) );
         for (size_t i = 0; i < num_cs; i++) {
-            bcsim::PointScatterer scatterer;
-            scatterer.amplitude = a_dist(gen);
-            scatterer.pos = bcsim::vector3(x_dist(gen), y_dist(gen), z_dist(gen));
-            control_points.push_back(scatterer);
+            spline_scatterers->control_points[scatterer_no].push_back( bcsim::vector3(x_dist(gen), y_dist(gen), z_dist(gen)) );
         }
-        spline_scatterers->nodes.push_back(control_points);
     }
 
     auto scatterers = bcsim::Scatterers::s_ptr(spline_scatterers);

--- a/src/qt5gui/MainWindow.cpp
+++ b/src/qt5gui/MainWindow.cpp
@@ -715,7 +715,7 @@ void MainWindow::onAboutScatterers() {
     
     if (spline_scatterers) {
         info += " spline scatterers of degree " + QString::number(spline_scatterers->spline_degree);
-        info += ", each consisting of " + QString::number(spline_scatterers->nodes[0].size()) + " control points.";
+        info += ", each consisting of " + QString::number(spline_scatterers->get_num_control_points()) + " control points.";
     } else if (fixed_scatterers) {
         info += " fixed scatterers.";
     } else {

--- a/src/qt5gui/MainWindow.cpp
+++ b/src/qt5gui/MainWindow.cpp
@@ -611,12 +611,12 @@ void MainWindow::initializeFixedVisualization(const QString& h5_file) {
 // Currently ignoring weights when visualizing
 void MainWindow::initializeSplineVisualization(const QString& h5_file) {
     SimpleHDF::SimpleHDF5Reader reader(h5_file.toUtf8().constData());
-    auto nodes       =  reader.readMultiArray<float, 3>("nodes");
-    auto knot_vector =  reader.readStdVector<float>("knot_vector");
-    int spline_degree = reader.readScalar<int>("spline_degree");
+    auto control_points =  reader.readMultiArray<float, 3>("control_points");
+    auto knot_vector    =  reader.readStdVector<float>("knot_vector");
+    int spline_degree   = reader.readScalar<int>("spline_degree");
 
-    auto shape = nodes.shape();
-    auto dimensionality = nodes.num_dimensions();
+    auto shape = control_points.shape();
+    auto dimensionality = control_points.num_dimensions();
     Q_ASSERT(dimensionality == 3);
     int num_scatterers = static_cast<int>(shape[0]);
     int num_cs = static_cast<int>(shape[1]);
@@ -644,7 +644,9 @@ void MainWindow::initializeSplineVisualization(const QString& h5_file) {
         curve.degree = spline_degree;
         curve.cs.resize(num_cs);
         for (int cs_no = 0; cs_no < num_cs; cs_no++) {
-            curve.cs[cs_no] = bcsim::vector3(nodes[ind][cs_no][0], nodes[ind][cs_no][1], nodes[ind][cs_no][2]);
+            curve.cs[cs_no] = bcsim::vector3(control_points[ind][cs_no][0],
+                                             control_points[ind][cs_no][1],
+                                             control_points[ind][cs_no][2]);
         }
         splines[scatterer_no] = curve;
     }


### PR DESCRIPTION
Switched to using a single scattering amplitude value for each scatterer spline.

This reduces the memory traffic in the GPU algorithms as well as reduces the size of stored phantoms. Updated simulator code, as well as code for making phantom scripts. Updated code for loading phantoms from hdf5, and updated Python interface. This closes #24.
