### PR TITLE
Improve cmake install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -241,7 +241,9 @@ endif()
 # Define installation of binaries and public API headers
 install(TARGETS LibBCSim DESTINATION lib)
 if (BCSIM_BUILD_PYTHON_INTERFACE)
-    install(TARGETS pyrfsim DESTINATION lib)
+    # put it in "bin" because it needs many of the same DLLs
+    # as the executables.
+    install(TARGETS pyrfsim DESTINATION bin)
 endif()
 
 install(FILES "${PROJECT_BINARY_DIR}/bcsim_defines.h" DESTINATION include)

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -7,6 +7,8 @@ if (BCSIM_ENABLE_CUDA)
     target_link_libraries(gpu_render_spline_comparison
                           ${CUDA_LIBRARIES}
                           )
+    install(TARGETS gpu_render_spline_comparison DESTINATION bin)
+                          
     
     cuda_add_executable(gpu_memcpy_speedtest
                         gpu_memcpy_speedtest.cu
@@ -15,6 +17,8 @@ if (BCSIM_ENABLE_CUDA)
     target_link_libraries(gpu_memcpy_speedtest
                           ${CUDA_LIBRARIES}
                           )
+    install(TARGETS gpu_memcpy_speedtest DESTINATION bin)
+                          
     cuda_add_executable(gpu_texture_example
                         gpu_texture_example.cu
                         ../algorithm/cuda_helpers.h
@@ -22,6 +26,8 @@ if (BCSIM_ENABLE_CUDA)
     target_link_libraries(gpu_texture_example
                           ${CUDA_LIBRARIES}
                           )
+    install(TARGETS gpu_texture_example DESTINATION bin)
+                          
     cuda_add_executable(gpu_3d_texture_example
                         gpu_3d_texture_example.cu
                         ../algorithm/cuda_helpers.h
@@ -29,4 +35,6 @@ if (BCSIM_ENABLE_CUDA)
     target_link_libraries(gpu_3d_texture_example
                           ${CUDA_LIBRARIES}
                          )
+    install(TARGETS gpu_3d_texture_example DESTINATION bin)
+    
 endif()

--- a/src/qt5gui/CMakeLists.txt
+++ b/src/qt5gui/CMakeLists.txt
@@ -65,3 +65,4 @@ if (BCSIM_ENABLE_QWT)
 endif()
                       
 
+install(TARGETS BCSimGUI DESTINATION bin)

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -17,4 +17,4 @@ target_link_libraries(all_tests
                       ${Boost_LIBRARIES}
                       ${HDF5_LIBRARIES}
                       )
-
+install(TARGETS all_tests DESTINATION bin)


### PR DESCRIPTION
All targets made with add_executable() should now be copied into "bin" when building the INSTALL target.
