### PR TITLE
Improve spline sum efficiency

### DIFF
--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -73,13 +73,15 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
 
     int lower_lim = 0;
     int upper_lim = num_control_points-1;
-    if (true) {
+    if (m_param_sum_all_cs) {
+        std::cout << "debug mode: summing over i = " << lower_lim << "..." << upper_lim << std::endl;
+    } else {
         std::tie(lower_lim, upper_lim) = bspline_storve::get_lower_upper_inds(m_scatterers->knot_vector,
                                                                               line.get_timestamp(),
                                                                               m_scatterers->spline_degree);
-    }
-    if (!sanity_check_spline_lower_upper_bound(basis_functions, lower_lim, upper_lim)) {
-        throw std::runtime_error("b-spline basis bounds failed sanity check");
+        if (!sanity_check_spline_lower_upper_bound(basis_functions, lower_lim, upper_lim)) {
+            throw std::runtime_error("b-spline basis bounds failed sanity check");
+        }
     }
 
     // Precompute all B-spline basis function for current timestep

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -90,7 +90,7 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
 
         // Compute position of current scatterer by evaluating spline in current timestep        
         vector3 scatterer_pos(0.0f, 0.0f, 0.0f);
-        for (int i = lower_lim; i < upper_lim; i++) {
+        for (int i = lower_lim; i <= upper_lim; i++) {
             scatterer_pos += m_scatterers->control_points[scatterer_no][i]*basis_functions[i];
         }
         

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -41,7 +41,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace bcsim {
 
 CpuSplineAlgorithm::CpuSplineAlgorithm()
-        : CpuBaseAlgorithm() { }
+        : CpuBaseAlgorithm(),
+          m_param_sum_all_cs(false) { }
      
 void CpuSplineAlgorithm::set_scatterers(Scatterers::s_ptr new_scatterers) {
     m_scatterers = std::dynamic_pointer_cast<SplineScatterers>(new_scatterers);
@@ -142,5 +143,20 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
         }
     }
 }
+
+void CpuSplineAlgorithm::set_parameter(const std::string& key, const std::string& value) {
+    if (key == "sum_all_cs") {
+        if ((value == "on") || (value == "true")) {
+            m_param_sum_all_cs = true;
+        } else if ((value == "off") || (value == "false")) {
+            m_param_sum_all_cs = false;
+        } else {
+            throw std::runtime_error("invalid value for " + key);
+        }
+    } else {
+        CpuBaseAlgorithm::set_parameter(key, value);
+    }
+}
+
 
 }   // namespace

--- a/src/algorithm/CpuSplineAlgorithm.cpp
+++ b/src/algorithm/CpuSplineAlgorithm.cpp
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "CpuSplineAlgorithm.hpp"
 #include "bspline.hpp"
 #include "safe_omp.h"
+#include "common_utils.hpp"
 
 namespace bcsim {
 
@@ -69,13 +70,15 @@ void CpuSplineAlgorithm::projection_loop(const Scanline& line, std::complex<floa
     
     int mu = bspline_storve::compute_knot_interval(m_scatterers->knot_vector, line.get_timestamp());
 
-
     int lower_lim = 0;
     int upper_lim = num_control_points-1;
     if (true) {
         std::tie(lower_lim, upper_lim) = bspline_storve::get_lower_upper_inds(m_scatterers->knot_vector,
                                                                               line.get_timestamp(),
                                                                               m_scatterers->spline_degree);
+    }
+    if (!sanity_check_spline_lower_upper_bound(basis_functions, lower_lim, upper_lim)) {
+        throw std::runtime_error("b-spline basis bounds failed sanity check");
     }
 
     // Precompute all B-spline basis function for current timestep

--- a/src/algorithm/CpuSplineAlgorithm.hpp
+++ b/src/algorithm/CpuSplineAlgorithm.hpp
@@ -43,12 +43,17 @@ public:
     
     virtual void set_scatterers(Scatterers::s_ptr new_scatterers) override;
 
+    virtual void set_parameter(const std::string& key, const std::string& value) override;
+
 protected:
     virtual void projection_loop(const Scanline& line, std::complex<float>* time_proj_signal, size_t num_time_samples) override;
 
 private:
     SplineScatterers::s_ptr    m_scatterers;
 
+    // Debug parameter: If true, sum over all B-spline basis functions instead of
+    // only those with non-zero basis functions. Result should be the same.
+    bool                       m_param_sum_all_cs;
 };
 
 

--- a/src/algorithm/GpuSplineAlgorithm1.cu
+++ b/src/algorithm/GpuSplineAlgorithm1.cu
@@ -187,7 +187,9 @@ void GpuSplineAlgorithm1::set_scan_sequence(ScanSequence::s_ptr new_scan_sequenc
     std::tie(cs_idx_start, cs_idx_end) = bspline_storve::get_lower_upper_inds(m_common_knots,
                                                                               PARAMETER_VAL,
                                                                               m_spline_degree);
-    sanity_check_spline_lower_upper_bound(host_basis_functions, cs_idx_start, cs_idx_end);
+    if (!sanity_check_spline_lower_upper_bound(host_basis_functions, cs_idx_start, cs_idx_end)) {
+        throw std::runtime_error("b-spline basis bounds failed sanity check");
+    }
 
     int num_threads = 128;
     int num_blocks = round_up_div(m_num_splines, num_threads);

--- a/src/algorithm/GpuSplineAlgorithm2.cu
+++ b/src/algorithm/GpuSplineAlgorithm2.cu
@@ -268,7 +268,9 @@ void GpuSplineAlgorithm2::projection_kernel(int stream_no, const Scanline& scanl
     std::tie(cs_idx_start, cs_idx_end) = bspline_storve::get_lower_upper_inds(m_common_knots,
                                                                               scanline.get_timestamp(),
                                                                               m_spline_degree);
-    sanity_check_spline_lower_upper_bound(host_basis_functions, cs_idx_start, cs_idx_end);
+    if (!sanity_check_spline_lower_upper_bound(host_basis_functions, cs_idx_start, cs_idx_end)) {
+        throw std::runtime_error("b-spline basis bounds failed sanity check");
+    }
 
     switch (m_cur_beam_profile_type) {
     case BeamProfileType::ANALYTICAL:

--- a/src/algorithm/common_utils.hpp
+++ b/src/algorithm/common_utils.hpp
@@ -40,4 +40,23 @@ size_t compute_num_rf_samples(T sound_speed, T line_length, T sampling_freq) {
     return static_cast<size_t>(std::floor(sampling_freq*max_time + 0.5)); 
 }
 
+// When evaluating a spline as a sum of control points and basis functions,
+// only degree+1 terms are non-zero. The start and end index (inclusive) can
+// be computed. This function asserts that the skipped basis functions are in
+// fact zero. Note that this function relies on a vector of all evaluated basis
+// functions.
+//
+// Returns true if test passes.
+template <typename T>
+bool sanity_check_spline_lower_upper_bound(const std::vector<T>& all_basis_functions,
+                                           int cs_idx_start, int cs_idx_end) {
+    for (int i = 0; i < cs_idx_start; i++) {
+        if (std::abs(all_basis_functions[i]) > 1e-6) return false;
+    }
+    for (int i = cs_idx_end+1; i < all_basis_functions.size(); i++) {
+        if (std::abs(all_basis_functions[i]) > 1e-6) return false;
+    }
+    return true;
+}
+
 }   // end namespace

--- a/src/bspline.hpp
+++ b/src/bspline.hpp
@@ -67,7 +67,8 @@ T bsplineBasis(int j, int p, T x, const std::vector<T>& knots) {
     }
 }
 
-// Determine which knot span a parameter value is in. Returns -1 on error.
+// Determine which knot span a parameter value is in.
+// Throws std::runtime_error if interval cannot be found.
 template <typename T>
 int compute_knot_interval(const std::vector<T>& knots, T t) {
     for (int i = 0; i < static_cast<int>(knots.size())-1; i++) {
@@ -75,7 +76,7 @@ int compute_knot_interval(const std::vector<T>& knots, T t) {
             return i;
         }
     }
-    return -1;
+    throw std::runtime_error(std::string(__FUNCTION__) + " : could not determine knot interval");
 }
 
 }   // end namespace

--- a/src/bspline.hpp
+++ b/src/bspline.hpp
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cmath>
 #include <vector>
+#include <utility>
 
 namespace bspline_storve {
 
@@ -77,6 +78,15 @@ int compute_knot_interval(const std::vector<T>& knots, T t) {
         }
     }
     throw std::runtime_error(std::string(__FUNCTION__) + " : could not determine knot interval");
+}
+
+// Compute lower and upper sum indices for the non-zero basis
+// functions. Both are inclusive.
+// Throw std::runtime_error on error.
+template <typename T>
+std::pair<int, int> get_lower_upper_inds(const std::vector<T>& knots, T t, int degree) {
+    const int mu = compute_knot_interval(knots, t);
+    return std::make_pair(mu-degree, mu);
 }
 
 }   // end namespace

--- a/src/bspline.hpp
+++ b/src/bspline.hpp
@@ -67,4 +67,15 @@ T bsplineBasis(int j, int p, T x, const std::vector<T>& knots) {
     }
 }
 
+// Determine which knot span a parameter value is in. Returns -1 on error.
+template <typename T>
+int compute_knot_interval(const std::vector<T>& knots, T t) {
+    for (int i = 0; i < static_cast<int>(knots.size())-1; i++) {
+        if ((t >= knots[i]) && (t < knots[i+1])) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 }   // end namespace


### PR DESCRIPTION
Now only the non-zero B-spline basis functions are transferred to device constant memory and the kernels are only reading control points associated with these. This reduces the memory bandwidth use to a constant number independent of the number of spline control points.

The constant memory allocations are now decided by the maximum supported spline degree (and number of streams for GPU spline algorithm 2). In practice, there is rarely any need to go higher than cubic degree.

There is still some sanity-checks left in the code that could be removed in the future. This closes #35.
