### PR TITLE
CUDA: improve compiling

### DIFF
--- a/COMPILE_INSTRUCTIONS.txt
+++ b/COMPILE_INSTRUCTIONS.txt
@@ -1,11 +1,26 @@
 # Compile instructions
-The entire project can be built using CMake. There is also an INSTALL target that will copy the public headers and all executables and libraries according to the CMake variable CMAKE_INSTALL_PREFIX. Note that this does not copy the required DLLs, which must be done manually.
+The entire project can be built using CMake. There is also an INSTALL target
+that will copy the public headers and all executables and libraries according
+to the CMake variable CMAKE_INSTALL_PREFIX. Note that this does not copy
+the required DLLs, which must be done manually.
 
 ## GPU
-After configuring CMake, some extra steps must be done. It is very important to set CUDA_NVCC_FLAGS to the correct architecture and compute capability. For a Quadro K4000M device, the following was successfully used:
-    CUDA_NVCC_FLAGS=-gencode arch=compute_30,code=sm_30
+The cache variable CUDA_NVCC_FLAGS is used to define NVCC compilation flags.
+By default,it is set up for JIT (just-in-time) compilation for compute_30 
+(Kepler) and compute_50 (Maxwell). Currently, Kepler is the lowest supported
+architecture because of usage of grids with large x-dimensions. (If necessary,
+it should be easy to modify the code for older hardware).
 
-Not setting this variable may result in strange behavior. For the K4000M device, the compiling was successful with empty CUDA_NVCC_FLAGS, but device refused to have more than 65535 as grid size x-component at runtime.
+It is also possible to change this to compile for a specific combination of
+virtual and real architecture, e.g. for K4000M (Kepler, sm_30):
+    CUDA_NVCC_FLAGS=-gencode=arch=compute_30,code=sm_30
 
-It is also possible to add the flag -use_fast_math, in which case the variable should look like:
-    CUDA_NVCC_FLAGS=-gencode arch=compute_30,code=sm_30;-use_fast_math
+NOTE: The compute_XX are virtual architectures, while sm_XX are real arch.
+When compiling for a specific architecture, it is also possible to add the
+flag --resource-usage to show details about hardware resources (this is not
+possible when using JIT).
+
+NOTE: The flags in the CMake cache variable CUDA_NVCC_FLAGS must be delimited
+with semicolons.
+
+The flag -use_fast_math is also added by default.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,8 +52,14 @@ endif ()
 
 if (BCSIM_ENABLE_CUDA)
     # default flags for JIT compilation targeting Kepler and Maxwell, with "fast-math" enabled.
-    set(CUDA_NVCC_FLAGS "-gencode=arch=compute_30,code=compute_30;-gencode=arch=compute_50,code=compute_50;-use_fast_math"
-        CACHE STRING "Semi-colon delimit multiple arguments.")
+    set(CUDA_NVCC_FLAGS_DEFAULT "-gencode=arch=compute_30,code=compute_30;-gencode=arch=compute_50,code=compute_50;-use_fast_math") 
+    if (CMAKE_COMPILER_IS_GNUCXX)
+        # must explicitly enable C++11 with GCC. Also, position independent code is 
+        # required on 64-bit systems, but should also work on 32-bit.
+        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS_DEFAULT};-std=c++11;-Xcompiler -fPIC" CACHE STRING "")
+    else()
+        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS_DEFAULT}" CACHE STRING "")
+    endif()
     find_package(CUDA REQUIRED)
     message(STATUS "Found CUDA version: ${CUDA_VERSION}")
     include_directories(${CUDA_INCLUDE_DIRS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,11 +51,12 @@ if (BCSIM_ENABLE_OPENMP)
 endif ()
 
 if (BCSIM_ENABLE_CUDA)
+    # default flags for JIT compilation targeting Kepler and Maxwell, with "fast-math" enabled.
+    set(CUDA_NVCC_FLAGS "-gencode=arch=compute_30,code=compute_30;-gencode=arch=compute_50,code=compute_50;-use_fast_math"
+        CACHE STRING "Semi-colon delimit multiple arguments.")
     find_package(CUDA REQUIRED)
     message(STATUS "Found CUDA version: ${CUDA_VERSION}")
     include_directories(${CUDA_INCLUDE_DIRS})
-    # default flags for JIT compilation targeting Kepler and Maxwell, with "fast-math" enabled.
-    set(CUDA_NVCC_FLAGS "-gencode=arch=compute_30,code=compute_30;-gencode=arch=compute_50,code=compute_50;-use_fast_math")
 endif()
 
 # Need to add -fPIC on 64-bit Linux

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,15 +54,8 @@ if (BCSIM_ENABLE_CUDA)
     find_package(CUDA REQUIRED)
     message(STATUS "Found CUDA version: ${CUDA_VERSION}")
     include_directories(${CUDA_INCLUDE_DIRS})
-    # Optimized flags: -O3-gencode arch=compute_30,code=sm_30;-use_fast_math
-    # Put in CUDA_NVCC_FLAGS_RELEASE
-    if(UNIX)
-        # Tell host compiler to use -fPIC
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-O3 -std=c++11 -Xcompiler -fPIC)
-    else()
-        # C++11 is enabled by default in MSVC
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-O3)
-    endif()
+    # default flags for JIT compilation targeting Kepler and Maxwell, with "fast-math" enabled.
+    set(CUDA_NVCC_FLAGS "-gencode=arch=compute_30,code=compute_30;-gencode=arch=compute_50,code=compute_50;-use_fast_math")
 endif()
 
 # Need to add -fPIC on 64-bit Linux

--- a/src/core/algorithm/cuda_kernels_spline1.cu
+++ b/src/core/algorithm/cuda_kernels_spline1.cu
@@ -3,10 +3,12 @@
 #include "cuda_kernels_spline1.cuh"
 #include "common_definitions.h" // for MAX_SPLINE_DEGREE
 
-__constant__ float eval_basis[MAX_SPLINE_DEGREE+1];
+// Named "eval_basis1" because of a strange linker error with MSVC when compiling
+// only for a virtual target in order to enable JIT compilation.
+__constant__ float eval_basis1[MAX_SPLINE_DEGREE+1];
 
 bool splineAlg1_updateConstantMemory_internal(float* src_ptr, size_t num_bytes) {
-    const auto res = cudaMemcpyToSymbol(eval_basis, src_ptr, num_bytes);
+    const auto res = cudaMemcpyToSymbol(eval_basis1, src_ptr, num_bytes);
     return (res == cudaSuccess);
 }
 
@@ -31,9 +33,9 @@ __global__ void RenderSplineKernel(const float* control_xs,
     float rendered_y = 0.0f;
     float rendered_z = 0.0f;
     for (int i = cs_idx_start; i <= cs_idx_end; i++) {
-        rendered_x += control_xs[NUM_SPLINES*i + idx]*eval_basis[i-cs_idx_start];
-        rendered_y += control_ys[NUM_SPLINES*i + idx]*eval_basis[i-cs_idx_start];
-        rendered_z += control_zs[NUM_SPLINES*i + idx]*eval_basis[i-cs_idx_start];
+        rendered_x += control_xs[NUM_SPLINES*i + idx]*eval_basis1[i-cs_idx_start];
+        rendered_y += control_ys[NUM_SPLINES*i + idx]*eval_basis1[i-cs_idx_start];
+        rendered_z += control_zs[NUM_SPLINES*i + idx]*eval_basis1[i-cs_idx_start];
     }
 
     // write result to memory


### PR DESCRIPTION
CUDA_NVCC_FLAGS now have suitable default values which should work on Linux and Windows out of the box. It is now configured for JIT compilation for Kepler and Maxwell.

Also updated the compile instructions.
