### PR TITLE
Improve python interface & mmode timing script

### DIFF
--- a/python/demo_mmode_gpu_spline_vs_fixed.py
+++ b/python/demo_mmode_gpu_spline_vs_fixed.py
@@ -112,6 +112,7 @@ if __name__ == "__main__":
     parser.add_argument("--end_time", help="Will reset to start time after this", type=float, default=0.999)
     parser.add_argument("--xz_tilt_angle", help="Control M-mode beam direction", type=float, default=0.0)
     parser.add_argument("--only_save_png", help="Only save two png images", action="store_true")
+    parser.add_argument("--gpu_device_no", help="Which GPU to use", type=int, default=0)
     args = parser.parse_args()
     
     c0 = 1540.0
@@ -148,7 +149,14 @@ if __name__ == "__main__":
     sim_fixed.set_parameter("sound_speed", "%f" % c0);  sim_spline.set_parameter("sound_speed", "%f" % c0)
     sim_fixed.set_parameter("phase_delay", "on");       sim_spline.set_parameter("phase_delay", "on")
     sim_fixed.set_parameter("radial_decimation", "5");  sim_spline.set_parameter("radial_decimation", "5")
-
+    
+    num_gpus = int(sim_fixed.get_parameter("num_cuda_devices"))
+    print "System has %d CUDA devices" % num_gpus
+    sim_fixed.set_parameter("gpu_device", "%d" % args.gpu_device_no)
+    sim_spline.set_parameter("gpu_device", "%d" % args.gpu_device_no)
+    print "Fixed simulator uses %s" % sim_fixed.get_parameter("cur_device_name")
+    print "Spline simulator uses %s" % sim_spline.get_parameter("cur_device_name")
+    
     # define excitation signal
     t_vector = np.arange(-16/args.fc, 16/args.fc, 1.0/args.fs)
     samples = np.array(gausspulse(t_vector, bw=args.bw, fc=args.fc), dtype="float32")

--- a/python/demo_mmode_gpu_spline_vs_fixed.py
+++ b/python/demo_mmode_gpu_spline_vs_fixed.py
@@ -5,7 +5,6 @@ import h5py
 from scipy.signal import gausspulse
 from time import time
 import math
-import matplotlib.pyplot as plt
 import sys
 sys.path.append("../phantom_scripts")
 import bsplines
@@ -112,6 +111,7 @@ if __name__ == "__main__":
     parser.add_argument("--start_time", help="Start time of simulation", type=float, default=0.0)
     parser.add_argument("--end_time", help="Will reset to start time after this", type=float, default=0.999)
     parser.add_argument("--xz_tilt_angle", help="Control M-mode beam direction", type=float, default=0.0)
+    parser.add_argument("--only_save_png", help="Only save two png images", action="store_true")
     args = parser.parse_args()
     
     c0 = 1540.0
@@ -179,14 +179,23 @@ if __name__ == "__main__":
     # fixed
     iq_lines_fixed, sim_time_fixed = run_fixed_simulation(sim_fixed, origin, direction, lateral_dir,
                                                           args.line_length, timestamps, fixed_scatterers)
+    if args.only_save_png:
+        import matplotlib
+        matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+        
     plt.figure(1)
     make_mmode_image(iq_lines_fixed)
     plt.title("M-Mode produced with the fixed algorithm : %f sec" % sim_time_fixed)
-    
+    if args.only_save_png:
+        plt.savefig("mmode_fixed_alg.png")
+
     # spline
     iq_lines_spline, sim_time_spline = run_spline_simulation(sim_spline)
     plt.figure(2)
     make_mmode_image(iq_lines_spline)
     plt.title("M-Mode produced with the spline algorithm : %f sec" % sim_time_spline)
-        
-    plt.show()
+    if args.only_save_png:
+        plt.savefig("mmode_spline_alg.png")
+    else:        
+        plt.show()

--- a/src/python/PythonInterface.cpp
+++ b/src/python/PythonInterface.cpp
@@ -308,6 +308,10 @@ public:
         return res;
     }
 
+    std::string get_parameter(const std::string& key) {
+        return m_rf_simulator->get_parameter(key);
+    }
+
 protected:
     IAlgorithm::s_ptr       m_rf_simulator;
     bool                    m_print_debug;
@@ -337,5 +341,6 @@ BOOST_PYTHON_MODULE(pyrfsim) {
         .def("set_lut_beam_profile",        &RfSimulatorWrapper::set_lut_beam_profile)
         .def("simulate_lines",              &RfSimulatorWrapper::simulate_lines)
         .def("get_debug_data",              &RfSimulatorWrapper::get_debug_data)
+        .def("get_parameter",               &RfSimulatorWrapper::set_parameter)
     ;
 }

--- a/src/python/PythonInterface.cpp
+++ b/src/python/PythonInterface.cpp
@@ -341,6 +341,6 @@ BOOST_PYTHON_MODULE(pyrfsim) {
         .def("set_lut_beam_profile",        &RfSimulatorWrapper::set_lut_beam_profile)
         .def("simulate_lines",              &RfSimulatorWrapper::simulate_lines)
         .def("get_debug_data",              &RfSimulatorWrapper::get_debug_data)
-        .def("get_parameter",               &RfSimulatorWrapper::set_parameter)
+        .def("get_parameter",               &RfSimulatorWrapper::get_parameter)
     ;
 }


### PR DESCRIPTION
Expose get_parameter() in Python interface, which is very useful for determining the name of the current GPU.

Updated the M-mode fixed vs. spline timing script to be usable without in non-GUI environments and to be able to control which GPU device is being used on muli-GPU systems.
