### PR TITLE
Replace stdout with log interface

### DIFF
--- a/src/core/BCSimConfig.hpp
+++ b/src/core/BCSimConfig.hpp
@@ -45,7 +45,7 @@ typedef Vector3D<float> vector3;
 class ILog {
 public:
     typedef std::shared_ptr<ILog> ptr;
-    enum class LogType {DEBUG, INFO, WARNING, FATAL};
+    enum LogType {DEBUG, INFO, WARNING, FATAL};
     virtual ~ILog() { }
     virtual void write(LogType type, const std::string& msg) = 0;
 };

--- a/src/core/BCSimConfig.hpp
+++ b/src/core/BCSimConfig.hpp
@@ -41,6 +41,21 @@ namespace bcsim {
 // NOTE: currently only float should be used.
 typedef Vector3D<float> vector3;
 
+// Log service object.
+class ILog {
+public:
+    typedef std::shared_ptr<ILog> ptr;
+    enum class LogType {DEBUG, INFO, WARNING, FATAL};
+    virtual ~ILog() { }
+    virtual void write(LogType type, const std::string& msg) = 0;
+};
+
+class DummyLog : public ILog {
+    virtual void write(LogType type, const std::string& msg) override {
+        // do nothing
+    }
+};
+
 struct Interval {
 public:
     Interval(float t0, float t1) : first(t0), last(t1) { }

--- a/src/core/LibBCSim.hpp
+++ b/src/core/LibBCSim.hpp
@@ -45,7 +45,7 @@ public:
     typedef std::unique_ptr<IAlgorithm> u_ptr;
     
     virtual ~IAlgorithm() { }
-            
+
     // Set misc. parameters. Available keys depends on the algorithm.
     virtual void set_parameter(const std::string&, const std::string& value)            = 0;
     
@@ -85,6 +85,9 @@ public:
 
     // Get the total number of scatterers (fixed and dynamic)
     virtual size_t get_total_num_scatterers() const = 0;
+
+    // Set log object to use (optional)
+    virtual void set_logger(ILog::ptr log_object) = 0;
 };
 
 // Factory function for creating simulator instances.

--- a/src/core/algorithm/BaseAlgorithm.cpp
+++ b/src/core/algorithm/BaseAlgorithm.cpp
@@ -40,7 +40,8 @@ BaseAlgorithm::BaseAlgorithm()
       m_param_use_arc_projection(true),
       m_radial_decimation(1),
       m_enable_phase_delay(false),
-      m_cur_beam_profile_type(BeamProfileType::NOT_CONFIGURED)
+      m_cur_beam_profile_type(BeamProfileType::NOT_CONFIGURED),
+      m_log_object(std::make_shared<DummyLog>())
 {
 }
 
@@ -95,6 +96,11 @@ std::vector<double> BaseAlgorithm::get_debug_data(const std::string& identifier)
 std::string BaseAlgorithm::get_parameter(const std::string& key) const {
     throw std::runtime_error("Illegal key: " + key);
 }
+
+void BaseAlgorithm::set_logger(ILog::ptr log_object) {
+    m_log_object = log_object;
+}
+
 
 }   // end namespace
 

--- a/src/core/algorithm/BaseAlgorithm.hpp
+++ b/src/core/algorithm/BaseAlgorithm.hpp
@@ -55,6 +55,8 @@ public:
 
     virtual std::vector<double> get_debug_data(const std::string& identifier)       const override;
 
+    virtual void set_logger(ILog::ptr log_object) override;
+
 protected:
     float       m_param_sound_speed;
     int         m_param_verbose;
@@ -68,6 +70,8 @@ protected:
 
     // storage of debug data
     std::map<std::string, std::vector<double>>  m_debug_data;
+    
+    ILog::ptr   m_log_object;   // class invariant: always valid (default dummy object)
 };
 
 }   // end namespace

--- a/src/core/algorithm/GpuAlgorithm.cpp
+++ b/src/core/algorithm/GpuAlgorithm.cpp
@@ -531,6 +531,8 @@ void GpuAlgorithm::dump_orthogonal_lut_slices(const std::string& raw_path) {
                                 origin, dir0, dir1, device_slice.data(), m_device_beam_profile->get());
         cudaErrorCheck( cudaDeviceSynchronize() );
         dump_device_buffer_as_raw_file(device_slice, raw_file);
+        m_log_object->write(ILog::DEBUG, "Wrote RAW file to " + raw_file);
+
     };
 
     // slice in the middle lateral-elevational plane (radial dist is 0.5)

--- a/src/core/algorithm/GpuAlgorithm.cpp
+++ b/src/core/algorithm/GpuAlgorithm.cpp
@@ -492,8 +492,11 @@ void GpuAlgorithm::set_lookup_profile(IBeamProfile::s_ptr beam_profile) {
             }
         }
     }
-    m_device_beam_profile = DeviceBeamProfileRAII::u_ptr(new DeviceBeamProfileRAII(DeviceBeamProfileRAII::TableExtent3D(num_samples_lat, num_samples_ele, num_samples_rad),
-                                                                                    temp_samples));
+    auto log_adapter = [&](const std::string& msg) {
+        m_log_object->write(ILog::DEBUG, msg);
+    };
+    const auto table_extent = DeviceBeamProfileRAII::TableExtent3D(num_samples_lat, num_samples_ele, num_samples_rad);
+    m_device_beam_profile = std::make_unique<DeviceBeamProfileRAII>(table_extent, temp_samples, log_adapter);
     // store spatial extent of profile.
     m_lut_r_min = r_range.first;
     m_lut_r_max = r_range.last;

--- a/src/core/algorithm/GpuAlgorithm.hpp
+++ b/src/core/algorithm/GpuAlgorithm.hpp
@@ -148,6 +148,7 @@ protected:
     float   m_lut_e_min;
     float   m_lut_e_max;
 
+    // TODO: set log callbacks!
     DeviceFixedScatterersCollection     m_device_fixed_datasets;
     DeviceSplineScatterersCollection    m_device_spline_datasets;
 

--- a/src/core/algorithm/GpuScatterers.hpp
+++ b/src/core/algorithm/GpuScatterers.hpp
@@ -38,6 +38,12 @@ private:
 // Device memory for multiple fixed-scatterer datasets
 class DeviceFixedScatterersCollection {
 public:
+    typedef std::function<void(const std::string&)> LogCallback;
+
+    DeviceFixedScatterersCollection(LogCallback log_callback = [](const std::string&) {}) {
+        m_log_callback = log_callback;
+    }
+
     // create a new dataset and fill it with data (will allocate memory on device)
     void add(bcsim::FixedScatterers::s_ptr host_scatterers);
 
@@ -61,14 +67,16 @@ public:
 
 private:
     std::vector<DeviceFixedScatterers::s_ptr>   m_fixed_datasets;
+    LogCallback                                 m_log_callback;
 };
 
 // Device memory for a spline-scatterer dataset.
 class DeviceSplineScatterers {
 public:
+    typedef std::function<void(const std::string&)> LogCallback;
     typedef std::shared_ptr<DeviceSplineScatterers> s_ptr;
 
-    DeviceSplineScatterers(bcsim::SplineScatterers::s_ptr host_scatterers);
+    DeviceSplineScatterers(bcsim::SplineScatterers::s_ptr host_scatterers, LogCallback log_callback_fn = [](const std::string&) {});
 
     // copy everything actual control points.
     void copy_information(bcsim::SplineScatterers::s_ptr host_scatterers);
@@ -118,6 +126,8 @@ private:
     
     // amplitudes: one per spline scatterer.
     DeviceBufferRAII<float>::u_ptr      m_as;
+    
+    LogCallback                         m_log_callback_fn;
 };
 
 // Device memory for multiple spline-scatterers datasets

--- a/src/core/algorithm/cuda_debug_utils.h
+++ b/src/core/algorithm/cuda_debug_utils.h
@@ -33,5 +33,4 @@ void dump_device_buffer_as_raw_file(DeviceBufferRAII<T>& device_buffer, const st
     }
 
     out_stream.close();
-    std::cout << "Wrote RAW file to " << raw_file << std::endl;
 }

--- a/src/core/algorithm/cuda_helpers.h
+++ b/src/core/algorithm/cuda_helpers.h
@@ -182,7 +182,8 @@ public:
     } TableExtent3D;
 
     DeviceBeamProfileRAII(const TableExtent3D& table_extent, std::vector<float>& host_input_buffer, LogCallback log_callback_fn=[](const std::string&) { })
-        : texture_object(0)
+        : texture_object(0),
+          m_log_callback_fn(log_callback_fn)
     {
         auto channel_desc = cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
         cudaExtent extent = make_cudaExtent(table_extent.lateral, table_extent.elevational, table_extent.radial);

--- a/src/qt5gui/CMakeLists.txt
+++ b/src/qt5gui/CMakeLists.txt
@@ -40,6 +40,7 @@ set(BCSimGUI_SOURCES
     QFileAdapter.cpp
     QSettingsConfigAdapter.cpp
     ImageExport.cpp
+    LogWidget.cpp
     )
 
 set(BCSimGUI_HEADERS
@@ -67,6 +68,7 @@ set(BCSimGUI_HEADERS
     IConfig.hpp
     QSettingsConfigAdapter.hpp
     ImageExport.hpp
+    LogWidget.hpp
     )
 
 add_executable(BCSimGUI

--- a/src/qt5gui/DisplayWidget.cpp
+++ b/src/qt5gui/DisplayWidget.cpp
@@ -3,7 +3,6 @@
 #include <QGraphicsPixmapItem>
 #include <QWheelEvent>
 #include <QVBoxLayout>
-#include <QDebug>
 #include <QStatusBar>
 #include "DisplayWidget.hpp"
 

--- a/src/qt5gui/GLScattererWidget.cpp
+++ b/src/qt5gui/GLScattererWidget.cpp
@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QMouseEvent>
 #include <QOpenGLShaderProgram>
 #include <QCoreApplication>
-#include <QDebug>
 #include "GLScattererWidget.hpp"
 #include "ScattererModel.hpp"
 #include "ScanSeqModel.hpp"
@@ -118,7 +117,8 @@ void GLScattererWidget::initializeGL() {
     
     initializeOpenGLFunctions();
     
-    qDebug("OpenGL initialized: version: %s GLSL: %s", glGetString(GL_VERSION), glGetString(GL_SHADING_LANGUAGE_VERSION));
+    // TODO: Use log object
+    //qDebug("OpenGL initialized: version: %s GLSL: %s", glGetString(GL_VERSION), glGetString(GL_SHADING_LANGUAGE_VERSION));
 
     glClearColor(0, 0, 0, m_transparent ? 0 : 1);
     

--- a/src/qt5gui/GLVisualizationWidget.cpp
+++ b/src/qt5gui/GLVisualizationWidget.cpp
@@ -104,9 +104,7 @@ void GLVisualizationWidget::updateTimestamp(float new_timestamp) {
     auto temp = m_scatterer_model.dynamicCast<SplineScattererModel>();
     if (temp) {
         temp->setTimestamp(new_timestamp);
-    } else {
-        qDebug() << "Cast to SplineScattererModel failed!";
-    }
+    } 
 
     glWidget->updateFromModel();
     update();
@@ -118,7 +116,9 @@ void GLVisualizationWidget::setScattererSplines(const std::vector<SplineCurve<fl
     input_qfile.open(QIODevice::ReadOnly);
     qfileadapter::InputAdapter adapter(input_qfile);
 	auto mesh3d = trianglemesh3d::LoadTriangleMesh3d(adapter(), trianglemesh3d::Mesh3dFileType::WAVEFRONT_OBJ);
-	qDebug() << "Loaded 3D model with" << mesh3d->num_vertices() << " vertices";
+	
+    // TODO: Use log object
+    //qDebug() << "Loaded 3D model with" << mesh3d->num_vertices() << " vertices";
 	auto temp = new SplineScattererModel(std::move(mesh3d), m_cfg);
     temp->setSplines(splines);
 

--- a/src/qt5gui/LogWidget.hpp
+++ b/src/qt5gui/LogWidget.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <iostream>
+
+// Temporary: this will become a proper widget.
+class ConsoleLog : public bcsim::ILog {
+    virtual void write(bcsim::ILog::LogType type, const std::string& msg) {
+        std::string prefix;
+        switch (type) {
+        case bcsim::ILog::DEBUG:
+            prefix = "[debug] ";
+            break;
+        case bcsim::ILog::FATAL:
+            prefix = "[fatal] ";
+            break;
+        case bcsim::ILog::INFO:
+            prefix = "[info] ";
+            break;
+        case bcsim::ILog::WARNING:
+            prefix = "[warning] ";
+            break;
+        }
+        std::cout << prefix << msg << std::endl;
+    }
+};

--- a/src/qt5gui/MainWindow.cpp
+++ b/src/qt5gui/MainWindow.cpp
@@ -71,6 +71,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "QSettingsConfigAdapter.hpp"
 
 MainWindow::MainWindow() {
+    m_log_widget = std::make_unique<ConsoleLog>();
     onLoadIniSettings();
 
     // Simulation time manager
@@ -469,8 +470,7 @@ void MainWindow::onSetSimulatorNoise() {
 
 void MainWindow::createNewSimulator(const QString sim_type) {
     m_sim = bcsim::Create(sim_type.toUtf8().constData());
-    
-    m_sim->set_logger(std::make_shared<ConsoleLog>());
+    m_sim->set_logger(m_log_widget);
     
     QString window_title_extra;
     if (sim_type == "cpu") {

--- a/src/qt5gui/MainWindow.cpp
+++ b/src/qt5gui/MainWindow.cpp
@@ -469,6 +469,9 @@ void MainWindow::onSetSimulatorNoise() {
 
 void MainWindow::createNewSimulator(const QString sim_type) {
     m_sim = bcsim::Create(sim_type.toUtf8().constData());
+    
+    m_sim->set_logger(std::make_shared<ConsoleLog>());
+    
     QString window_title_extra;
     if (sim_type == "cpu") {
         const auto num_cores = m_settings->value("cpu_sim_num_cores", 1).toInt();

--- a/src/qt5gui/MainWindow.hpp
+++ b/src/qt5gui/MainWindow.hpp
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
+#include <iostream>
 #include <memory>
 #include <QApplication>
 #include <QMainWindow>
@@ -55,6 +56,28 @@ class QTimer;
 namespace refresh_worker {
     class RefreshWorker;
 }
+
+// Temporary
+class ConsoleLog : public bcsim::ILog {
+    virtual void write(bcsim::ILog::LogType type, const std::string& msg) {
+        std::string prefix;
+        switch (type) {
+        case bcsim::ILog::DEBUG:
+            prefix = "[debug] ";
+            break;
+        case bcsim::ILog::FATAL:
+            prefix = "[fatal] ";
+            break;
+        case bcsim::ILog::INFO:
+            prefix = "[info] ";
+            break;
+        case bcsim::ILog::WARNING:
+            prefix = "[warning] ";
+            break;
+        }
+        std::cout << prefix << msg << std::endl;
+    }
+};
 
 class MainWindow : public QMainWindow {
     Q_OBJECT

--- a/src/qt5gui/MainWindow.hpp
+++ b/src/qt5gui/MainWindow.hpp
@@ -33,7 +33,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QApplication>
 #include <QMainWindow>
 #include <QSlider>
-#include <QDebug>
 #include <QSettings>
 #include "../core/LibBCSim.hpp"
 #include "SimTimeManager.hpp"

--- a/src/qt5gui/MainWindow.hpp
+++ b/src/qt5gui/MainWindow.hpp
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "SimTimeManager.hpp"
 #include "../utils/ScanGeometry.hpp"
 #include "ImageExport.hpp"
+#include "LogWidget.hpp"
 
 // Forward decl.
 class DisplayWidget;
@@ -56,28 +57,6 @@ class QTimer;
 namespace refresh_worker {
     class RefreshWorker;
 }
-
-// Temporary
-class ConsoleLog : public bcsim::ILog {
-    virtual void write(bcsim::ILog::LogType type, const std::string& msg) {
-        std::string prefix;
-        switch (type) {
-        case bcsim::ILog::DEBUG:
-            prefix = "[debug] ";
-            break;
-        case bcsim::ILog::FATAL:
-            prefix = "[fatal] ";
-            break;
-        case bcsim::ILog::INFO:
-            prefix = "[info] ";
-            break;
-        case bcsim::ILog::WARNING:
-            prefix = "[warning] ";
-            break;
-        }
-        std::cout << prefix << msg << std::endl;
-    }
-};
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -208,6 +187,8 @@ private:
     // Needed for color Doppler since a packet of frames must be simulated
     // with different timestamps.
     bcsim::ScanSequence::s_ptr      m_cur_scanseq;
+
+    bcsim::ILog::ptr                m_log_widget;
 };
 
 

--- a/src/qt5gui/ProbeWidget.cpp
+++ b/src/qt5gui/ProbeWidget.cpp
@@ -184,7 +184,9 @@ QVector3D DynamicProbeWidget::get_origin(float time) const {
     } else {
         // linear interpolation
         const auto k = (time-start_time)/(end_time-start_time);
-        qDebug() << "DynamicProbeWidget: interpolation constant is " << k;
+        
+        // TODO: Use log object
+        //qDebug() << "DynamicProbeWidget: interpolation constant is " << k;
         return k*p2 + (1-k)*p1;
     }
 };

--- a/src/qt5gui/RefreshWorker.hpp
+++ b/src/qt5gui/RefreshWorker.hpp
@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 #include <memory>
 #include <QObject>
-#include <QDebug>
 #include <QThread>
 #include <QTimer>
 #include <QMutex>
@@ -172,7 +171,6 @@ private:
             } else if (std::dynamic_pointer_cast<WorkTask_ColorDoppler>(work_task)) {
                 process(std::dynamic_pointer_cast<WorkTask_ColorDoppler>(work_task));
             } else {
-                qDebug() << "Unable to cast WorkTask";
                 throw std::logic_error("Unable to cast WorkTask");
             }
         }
@@ -309,7 +307,6 @@ private:
         }
 
         const auto max_r0_value = bcsim::get_max_value(r0_lines);
-        qDebug() << "Max R0 value is " << max_r0_value;
 
         m_color_cartesianator->SetGeometry(work_task->m_scan_geometry);
 

--- a/src/qt5gui/SimTimeWidget.hpp
+++ b/src/qt5gui/SimTimeWidget.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <QDebug>
 #include <QHBoxLayout>
 #include <QWidget>
 #include <QSlider>
@@ -59,7 +58,6 @@ private:
 private slots:
     void on_slider_changed(int new_value) {
         const auto new_time_value = to_float(new_value);
-        //qDebug() << "on_slider_changed: " << new_value << "==>" << new_time_value;
         emit time_changed(new_time_value);
     }
 

--- a/src/qt5gui/main.cpp
+++ b/src/qt5gui/main.cpp
@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QSurfaceFormat>
-#include <QDebug>
 #include "MainWindow.hpp"
 #include "utils.hpp"
 
@@ -41,7 +40,7 @@ int main(int argc, char** argv) try {
     QSurfaceFormat fmt;
     fmt.setDepthBufferSize(24);
     //if (QCoreApplication::arguments().contains(QStringLiteral("--multisample"))) {
-        qDebug() << "Using multisample";
+        std::cout << "Using multisample" << std::endl;;
         fmt.setSamples(4);
     //}
     // Hard-coded to use the core profile.

--- a/src/qt5gui/scanseq/LinearScanseqWidget.cpp
+++ b/src/qt5gui/scanseq/LinearScanseqWidget.cpp
@@ -4,7 +4,6 @@
 #include <QDoubleSpinBox>
 #include <QPushButton>
 #include <QGroupBox>
-#include <QDebug>
 #include "../../core/to_string.hpp"
 #include "../../utils/rotation3d.hpp"
 

--- a/src/qt5gui/scanseq/SectorScanseqWidget.cpp
+++ b/src/qt5gui/scanseq/SectorScanseqWidget.cpp
@@ -4,7 +4,6 @@
 #include <QDoubleSpinBox>
 #include <QPushButton>
 #include <QGroupBox>
-#include <QDebug>
 #include "../../core/to_string.hpp"
 
 SectorScanseqWidget::SectorScanseqWidget(QWidget* parent)


### PR DESCRIPTION
Added abstract ILog interface and a console implementation in qt5gui.
All use of std::cout in simulator has been updated to use the log object. The console object in qt5gui should be replaced with a GUI widget.

This closes #82.
