### PR TITLE
Added missing DLL_PUBLIC markers

### DIFF
--- a/src/qt5gui/trianglemesh3d/TriangleMesh3d.hpp
+++ b/src/qt5gui/trianglemesh3d/TriangleMesh3d.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <ostream>
+#include "../../core/export_macros.hpp" // TODO: Better solution?
 
 namespace trianglemesh3d {
 
@@ -9,7 +10,7 @@ enum class Mesh3dFileType {
 };
 
 // A 3D triangle mesh with normals.
-class ITriangleMesh3d {
+class DLL_PUBLIC ITriangleMesh3d {
 public:
 	typedef std::unique_ptr<ITriangleMesh3d> u_ptr;
 	virtual ~ITriangleMesh3d() { }
@@ -24,13 +25,13 @@ public:
     virtual const double* normal_data() const = 0;
 };
 
-std::ostream& operator<<(std::ostream& os, const ITriangleMesh3d& mesh);
+DLL_PUBLIC std::ostream& operator<<(std::ostream& os, const ITriangleMesh3d& mesh);
 
 // Load model from a file.
-ITriangleMesh3d::u_ptr LoadTriangleMesh3d(const std::string& filename, Mesh3dFileType type);
+DLL_PUBLIC ITriangleMesh3d::u_ptr LoadTriangleMesh3d(const std::string& filename, Mesh3dFileType type);
 
 // Load model from an input stream. This is useful in case the model file is
 // not a file on disk, but e.g. a Qt resource file embedded in an executable.
-ITriangleMesh3d::u_ptr LoadTriangleMesh3d(std::istream& in_stream, Mesh3dFileType type);
+DLL_PUBLIC ITriangleMesh3d::u_ptr LoadTriangleMesh3d(std::istream& in_stream, Mesh3dFileType type);
 
 }   // end namespace

--- a/src/utils/DefaultPhantoms.hpp
+++ b/src/utils/DefaultPhantoms.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include "EllipsoidGeometry.hpp"
 #include "core/BCSimConfig.hpp"
+#include "core/export_macros.hpp"
 
 namespace default_phantoms {
 
@@ -38,7 +39,7 @@ struct LeftVentriclePhantomParameters {
 // Create a LV spline phantom model by randomly distributing point-scatterers in a box and then removing
 // those who are not inside a 3D capped ellipsoid. The remaining points are then scaled and rotated
 // to generate control points for splines.
-class LeftVentricle3dPhantomFactory {
+class DLL_PUBLIC LeftVentricle3dPhantomFactory {
 public:
     typedef std::function<void(const std::string&)> LogCallback;
 

--- a/src/utils/HDFConvenience.hpp
+++ b/src/utils/HDFConvenience.hpp
@@ -52,7 +52,7 @@ ScanSequence::u_ptr DLL_PUBLIC loadScanSequenceFromHdf(const std::string& h5_fil
 ExcitationSignal DLL_PUBLIC loadExcitationFromHdf(const std::string& h5_file);
 
 // Load a LUT beam profile.
-IBeamProfile::s_ptr loadBeamProfileFromHdf(const std::string& h5_file);
+IBeamProfile::s_ptr DLL_PUBLIC loadBeamProfileFromHdf(const std::string& h5_file);
 
 }   // namespace
 

--- a/src/utils/HardwareAutodetection.hpp
+++ b/src/utils/HardwareAutodetection.hpp
@@ -1,11 +1,12 @@
 #pragma once
 #include <string>
 #include <vector>
+#include "../core/export_macros.hpp"
 
 namespace utils {
 
 // Detect CPU and GPU hardware.
-class HardwareAutodetector {
+class DLL_PUBLIC HardwareAutodetector {
 public:
     // Throws std::runtime_error on error.
     HardwareAutodetector();

--- a/src/utils/cartesianator/Cartesianator.hpp
+++ b/src/utils/cartesianator/Cartesianator.hpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <vector>
 #include "../ScanGeometry.hpp"
+#include "core/export_macros.hpp"
 
 // Geometry + Beam Space data => Sampled cartesian grid.
 // Manages its own output buffer.
@@ -63,7 +64,7 @@ public:
 };
 
 template <typename T>
-class CpuCartesianator : public ICartesianator<T> {
+class DLL_PUBLIC CpuCartesianator : public ICartesianator<T> {
 public:
     CpuCartesianator();
 


### PR DESCRIPTION
These are needed for building the GUI app and were forgotten because mostly static libs has been used on Linux during development, masking the symbol-exporting issue. 

It would perhaps be better if not including export_macros.hpp from core, but instead using CMake functionality for generating such export macros?
