### PR TITLE
Improve cmake hdf5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,15 +34,12 @@ include_directories(${PROJECT_SOURCE_DIR})
 find_package(Boost REQUIRED)
 
 if (BCSIM_BUILD_UTILS OR BCSIM_BUILD_QT5_GUI)
-    # Note: Using the new-style find_package() from HDF5 which
-    # makes available imported targets.
-    # Then it is no longer needed to do manually do include_directories()
+    # Note: Prefer the new-style find_package() for HDF5 which creates imported targets.
+    # Then it is no longer needed to manually do include_directories().
     find_package(HDF5 REQUIRED COMPONENTS C CXX)
-    if (NOT TARGET hdf5-shared)
-        message(FATAL_ERROR "Imported target hdf5-shared is not available")
-    endif()
-    if (NOT TARGET hdf5_cpp-shared)
-        message(FATAL_ERROR "Imported target hdf5_cpp-shared is not available")
+    if (NOT TARGET hdf5-shared OR NOT TARGET hdf5_cpp-shared)
+        message(WARNING "Could not find imported HDF5 targets. Using module-mode instead.")
+        include_directories(${HDF5_INCLUDE_DIRS}) 
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ if (BCSIM_BUILD_UTILS OR BCSIM_BUILD_QT5_GUI)
     # Note: Using the new-style find_package() from HDF5 which
     # makes available imported targets.
     # Then it is no longer needed to do manually do include_directories()
-    find_package(HDF5 REQUIRED)
+    find_package(HDF5 REQUIRED COMPONENTS C CXX)
     if (NOT TARGET hdf5-shared)
         message(FATAL_ERROR "Imported target hdf5-shared is not available")
     endif()

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -26,8 +26,8 @@ target_link_libraries(pyrfsim
                       Boost::python
                       Boost::system
                       LibBCSim
-                      hdf5-static
-                      hdf5_cpp-static
+                      hdf5-shared
+                      hdf5_cpp-shared
                       )
 set_target_properties(pyrfsim PROPERTIES PREFIX "")
 if (WIN32)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -26,9 +26,13 @@ target_link_libraries(pyrfsim
                       Boost::python
                       Boost::system
                       LibBCSim
-                      hdf5-shared
-                      hdf5_cpp-shared
                       )
+if (TARGET hdf5-shared AND TARGET hdf5_cpp-shared)
+    target_link_libraries(pyrfsim hdf5-shared hdf5_cpp-shared)
+else()
+    target_link_libraries(pyrfsim ${HDF5_LIBRARIES})
+endif()
+                      
 set_target_properties(pyrfsim PROPERTIES PREFIX "")
 if (WIN32)
 set_target_properties(pyrfsim PROPERTIES SUFFIX ".pyd")

--- a/src/qt5gui/CMakeLists.txt
+++ b/src/qt5gui/CMakeLists.txt
@@ -92,10 +92,15 @@ target_link_libraries(BCSimGUI
                       Boost::boost
                       LibBCSim
                       LibBCSimUtils # BCSimCUDA also?
-                      hdf5-shared
-                      hdf5_cpp-shared
                       trianglemesh3d
                       )
+
+if (TARGET hdf5-shared AND TARGET hdf5_cpp-shared)
+    target_link_libraries(BCSimGUI hdf5-shared hdf5_cpp-shared)
+else()
+    target_link_libraries(BCSimGUI ${HDF5_LIBRARIES})
+endif()
+
 if (WIN32)
     target_link_libraries(BCSimGUI Qt5::WinMain)
 endif()

--- a/src/qt5gui/CMakeLists.txt
+++ b/src/qt5gui/CMakeLists.txt
@@ -92,8 +92,8 @@ target_link_libraries(BCSimGUI
                       Boost::boost
                       LibBCSim
                       LibBCSimUtils # BCSimCUDA also?
-                      hdf5-static
-                      hdf5_cpp-static
+                      hdf5-shared
+                      hdf5_cpp-shared
                       trianglemesh3d
                       )
 if (WIN32)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -25,8 +25,8 @@ list(APPEND UTILS_LIBRARY_SOURCE_FILES
 
 add_library(LibBCSimUtils ${UTILS_LIBRARY_SOURCE_FILES})
 target_link_libraries(LibBCSimUtils
-                      hdf5-static
-                      hdf5_cpp-static
+                      hdf5-shared
+                      hdf5_cpp-shared
                       Boost::boost
                       )
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -25,11 +25,15 @@ list(APPEND UTILS_LIBRARY_SOURCE_FILES
 
 add_library(LibBCSimUtils ${UTILS_LIBRARY_SOURCE_FILES})
 target_link_libraries(LibBCSimUtils
-                      hdf5-shared
-                      hdf5_cpp-shared
                       Boost::boost
                       )
 
+if (TARGET hdf5-shared AND TARGET hdf5_cpp-shared)
+    target_link_libraries(LibBCSimUtils hdf5-shared hdf5_cpp-shared)
+else()
+    target_link_libraries(LibBCSimUtils ${HDF5_LIBRARIES})
+endif()
+                      
 if (BCSIM_ENABLE_CUDA)
     # Needed because we're going to interact with the CUDA runtime API
     # to query the number and type of available GPUs.


### PR DESCRIPTION
Make more flexible in order to support handling HDF5 dependency with module-type ```find_package()``` as well.

CMake's ```find_package()``` command can be used in both "config" and "module" mode. Previously only "config" mode was supported for the HDF5 library.

This closes #112 